### PR TITLE
BACKLOG-17078: Allow to define the functionScore to be used for scoring hits

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jahia/search-ui-jahia-connector",
-  "version": "2.0.10",
+  "version": "2.0.11",
   "description": "A Search UI connector for Jahia GraphQL Search API",
   "license": "MIT",
   "main": "dist",

--- a/src/JahiaSearchAPIConnector.js
+++ b/src/JahiaSearchAPIConnector.js
@@ -12,6 +12,7 @@ class JahiaSearchAPIConnector {
      * @param  {string} language Language in which search will be performed
      * @param  {string} workspace Workspace in which search will be performed
      * @param  {string} nodeType The node type that should be searched for
+     * @param  {string} functionScore The function score id that should be used to score the hits
      */
     constructor({
         apiToken,
@@ -19,7 +20,8 @@ class JahiaSearchAPIConnector {
         siteKey,
         language = Constants.LANGUAGE,
         workspace = Constants.WORKSPACE,
-        nodeType
+        nodeType,
+        functionScore = ''
     }) {
         if (!apiToken || !baseURL || !siteKey) {
             throw new Error(
@@ -33,6 +35,7 @@ class JahiaSearchAPIConnector {
         this.language = language;
         this.workspace = workspace;
         this.nodeType = nodeType;
+        this.functionScore = functionScore;
     }
 
     async onSearch(state, queryConfig) {
@@ -41,7 +44,8 @@ class JahiaSearchAPIConnector {
             siteKey: this.siteKey,
             language: this.language,
             workspace: this.workspace,
-            nodeType: this.nodeType
+            nodeType: this.nodeType,
+            functionScore: this.functionScore
         };
         const query = adaptRequest(requestOptions, state, queryConfig);
         const responseJson = await request(this.apiToken, this.baseURL, 'POST', query);
@@ -60,7 +64,8 @@ class JahiaSearchAPIConnector {
                 siteKey: this.siteKey,
                 language: this.language,
                 workspace: this.workspace,
-                nodeType: this.nodeType
+                nodeType: this.nodeType,
+                functionScore: this.functionScore
             };
             const query = adaptRequest(requestOptions,
                 {searchTerm},

--- a/src/__tests__/__snapshots__/sort.test.js.snap
+++ b/src/__tests__/__snapshots__/sort.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`Sort parameters tests Query with incorrect sort direction 1`] = `
 "{
-  search(q: \\"\\", siteKeys: [\\"fake\\"], language: \\"fake\\", workspace: fake, filters: {nodeType: {type: \\"fake\\"}}) {
+  search(q: \\"\\", siteKeys: [\\"fake\\"], language: \\"fake\\", workspace: fake, functionScoreId: \\"fake\\", filters: {nodeType: {type: \\"fake\\"}}) {
     results(size: 5, page: 0) {
       totalHits
       took
@@ -22,7 +22,7 @@ exports[`Sort parameters tests Query with incorrect sort direction 1`] = `
 
 exports[`Sort parameters tests Query with incorrect sort field 1`] = `
 "{
-  search(q: \\"\\", siteKeys: [\\"fake\\"], language: \\"fake\\", workspace: fake, filters: {nodeType: {type: \\"fake\\"}}) {
+  search(q: \\"\\", siteKeys: [\\"fake\\"], language: \\"fake\\", workspace: fake, functionScoreId: \\"fake\\", filters: {nodeType: {type: \\"fake\\"}}) {
     results(size: 5, page: 0) {
       totalHits
       took
@@ -42,7 +42,7 @@ exports[`Sort parameters tests Query with incorrect sort field 1`] = `
 
 exports[`Sort parameters tests Query with sort 1`] = `
 "{
-  search(q: \\"\\", siteKeys: [\\"fake\\"], language: \\"fake\\", workspace: fake, filters: {nodeType: {type: \\"fake\\"}}) {
+  search(q: \\"\\", siteKeys: [\\"fake\\"], language: \\"fake\\", workspace: fake, functionScoreId: \\"fake\\", filters: {nodeType: {type: \\"fake\\"}}) {
     results(size: 5, page: 0, sortBy: {dir: ASC, field: \\"jcr:title\\"}) {
       totalHits
       took
@@ -62,7 +62,7 @@ exports[`Sort parameters tests Query with sort 1`] = `
 
 exports[`Sort parameters tests Query without sort 1`] = `
 "{
-  search(q: \\"\\", siteKeys: [\\"fake\\"], language: \\"fake\\", workspace: fake, filters: {nodeType: {type: \\"fake\\"}}) {
+  search(q: \\"\\", siteKeys: [\\"fake\\"], language: \\"fake\\", workspace: fake, functionScoreId: \\"fake\\", filters: {nodeType: {type: \\"fake\\"}}) {
     results(size: 5, page: 0) {
       totalHits
       took

--- a/src/__tests__/adaptRequest.test.js
+++ b/src/__tests__/adaptRequest.test.js
@@ -6,15 +6,16 @@ import filters from '../filters';
 const defaultRequestOptions = {
     siteKey: 'academy',
     language: 'en',
-    workspace: 'LIVE'
+    workspace: 'LIVE',
+    functionScore: ''
 };
 
 const nodeTypeRequestOptions = {
     siteKey: 'academy',
     language: 'en',
     workspace: 'LIVE',
-    nodeType: 'jnt:page'
-
+    nodeType: 'jnt:page',
+    functionScore: ''
 };
 
 const queryConfig = {
@@ -117,7 +118,7 @@ const defaultRequest = {
 };
 
 const adaptedDefaultRequest = print(parse(`{
-      search (q: "test", siteKeys: ["academy"], language: "en", workspace: LIVE) {
+      search (q: "test", siteKeys: ["academy"], language: "en", workspace: LIVE, functionScoreId: "") {
             results (size: 10, page: 3, sortBy: {dir: ASC, field: "title"}) {
                 totalHits
                 took
@@ -166,7 +167,7 @@ const adaptedDefaultRequest = print(parse(`{
 }`));
 
 const adaptedNodeTypeFilterRequest = print(parse(`{
-      search (q: "test", siteKeys: ["academy"], language: "en", workspace: LIVE, filters: {nodeType: {type: "jnt:page"}}) {
+      search (q: "test", siteKeys: ["academy"], language: "en", workspace: LIVE, functionScoreId: "", filters: {nodeType: {type: "jnt:page"}}) {
             results (size: 10, page: 3, sortBy: {dir: ASC, field: "title"}) {
                 totalHits
                 took
@@ -215,7 +216,7 @@ const adaptedNodeTypeFilterRequest = print(parse(`{
 }`));
 
 const adaptedFilteredRequest = print(parse(`{
-      search (q: "test", siteKeys: ["academy"], language: "en", workspace: LIVE,
+      search (q: "test", siteKeys: ["academy"], language: "en", workspace: LIVE, functionScoreId: ""
             filters:{
                 custom:{
                     term:[{

--- a/src/__tests__/sort.test.js
+++ b/src/__tests__/sort.test.js
@@ -21,7 +21,8 @@ describe('Sort parameters tests', function () {
         siteKey: 'fake',
         language: 'fake',
         workspace: 'fake',
-        nodeType: 'fake'
+        nodeType: 'fake',
+        functionScore: 'fake'
     };
 
     it('Query without sort', function () {

--- a/src/adaptRequest.js
+++ b/src/adaptRequest.js
@@ -62,7 +62,8 @@ export default function adaptRequest(requestOptions, request, queryConfig) {
             q: "${graphQLOptions.searchTerm !== undefined ? htmlEscape(graphQLOptions.searchTerm) : ''}",
             siteKeys: ["${graphQLOptions.siteKey}"],
             language: "${graphQLOptions.language}",
-            workspace: ${graphQLOptions.workspace}
+            workspace: ${graphQLOptions.workspace},
+            functionScoreId: "${graphQLOptions.functionScore}",
             ${filters(request, queryConfig, graphQLOptions)}
             ) {
 


### PR DESCRIPTION


<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## Description
https://jira.jahia.org/browse/BACKLOG-17078

Add functionScore as a parameter of JahiaSearchAPIConnector constructor and pass it down the request.

## Tests

The following are included in this PR
- [X] Unit Tests (Most changes _should_ have unit tests)
- [ ] Integration Tests

