### PR TITLE
feat!: send the search query with GraphQL variables

### DIFF
--- a/.chachalog/Hb9tLx4v.md
+++ b/.chachalog/Hb9tLx4v.md
@@ -1,0 +1,10 @@
+---
+# Allowed version bumps: patch, minor, major
+search-ui-jahia-connector: major
+---
+
+Fixed searches containing quotes, ampersands, angle brackets or line breaks, which were altered or rejected before.
+
+Search terms are now sent to Jahia exactly as typed. Previously they were HTML-escaped into the query text, so someone searching for `Ben & Jerry's` actually searched for `Ben &amp; Jerry&#39;s`, and pasting anything containing a line break failed the search outright. The same applies to facet values: selecting a value containing a quote used to break the search. Also fixed: a facet range starting at 0 no longer loses its lower bound, a hierarchical facet with no root path no longer sends the text "undefined", and searching for `0` now returns results for `0` instead of everything.
+
+BREAKING: the search query is now sent with GraphQL variables rather than with every value written into the query text, which is what makes the above safe. If you call `Field.resolveRequestField()` yourself it now takes an argument and you should stop calling it directly — it is internal to building the query. If you pass a `workspace` that is not a valid GraphQL enum name, or a sort direction that is not one, the connector now reports the problem instead of sending a query the server rejects; check those values are plain names such as `LIVE` or `ASC`. Applications that only configure the connector and render Search UI components need no changes.

--- a/src/JahiaSearchAPIConnector.ts
+++ b/src/JahiaSearchAPIConnector.ts
@@ -75,8 +75,8 @@ class JahiaSearchAPIConnector {
             nodeType: this.nodeType,
             functionScore: this.functionScore
         };
-        const query = adaptRequest(requestOptions, state, queryConfig);
-        const responseJson = await request<SearchResponse>(this.apiToken, this.baseURL, 'POST', query);
+        const graphQLRequest = adaptRequest(requestOptions, state, queryConfig);
+        const responseJson = await request<SearchResponse>(this.apiToken, this.baseURL, 'POST', graphQLRequest);
         return adaptResponse(responseJson, state.resultsPerPage, queryConfig);
     }
 
@@ -95,12 +95,12 @@ class JahiaSearchAPIConnector {
                 nodeType: this.nodeType,
                 functionScore: this.functionScore
             };
-            const query = adaptRequest(requestOptions,
+            const graphQLRequest = adaptRequest(requestOptions,
                 {searchTerm},
                 queryConfig
             );
 
-            return request<SearchResponse>(this.apiToken, this.baseURL, 'POST', query).then(json => ({
+            return request<SearchResponse>(this.apiToken, this.baseURL, 'POST', graphQLRequest).then(json => ({
                 autocompletedResults: adaptResponse(json, queryConfig.results!.resultsPerPage, queryConfig).results
             }));
         }

--- a/src/__tests__/__snapshots__/sort.test.ts.snap
+++ b/src/__tests__/__snapshots__/sort.test.ts.snap
@@ -1,16 +1,17 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`Sort parameters tests > Query with incorrect sort direction 1`] = `
-"{
+{
+  "query": "query ($created_name: String!, $q: String!, $siteKey: String!, $language: String!, $functionScoreId: String!, $nodeType: String!, $size: Int!, $page: Int!) {
   search(
-    q: ""
-    siteKeys: ["fake"]
-    language: "fake"
+    q: $q
+    siteKeys: [$siteKey]
+    language: $language
     workspace: fake
-    functionScoreId: "fake"
-    filters: { nodeType: { type: "fake" } }
+    functionScoreId: $functionScoreId
+    filters: { nodeType: { type: $nodeType } }
   ) {
-    results(size: 5, page: 0) {
+    results(size: $size, page: $page) {
       totalHits
       took
       hits {
@@ -19,24 +20,36 @@ exports[`Sort parameters tests > Query with incorrect sort direction 1`] = `
         displayableName
         excerpt
         score
-        created: property(name: "jcr:created")
+        created: property(name: $created_name)
       }
     }
   }
-}"
+}",
+  "variables": {
+    "created_name": "jcr:created",
+    "functionScoreId": "fake",
+    "language": "fake",
+    "nodeType": "fake",
+    "page": 0,
+    "q": "",
+    "siteKey": "fake",
+    "size": 5,
+  },
+}
 `;
 
 exports[`Sort parameters tests > Query with incorrect sort field 1`] = `
-"{
+{
+  "query": "query ($created_name: String!, $q: String!, $siteKey: String!, $language: String!, $functionScoreId: String!, $nodeType: String!, $size: Int!, $page: Int!) {
   search(
-    q: ""
-    siteKeys: ["fake"]
-    language: "fake"
+    q: $q
+    siteKeys: [$siteKey]
+    language: $language
     workspace: fake
-    functionScoreId: "fake"
-    filters: { nodeType: { type: "fake" } }
+    functionScoreId: $functionScoreId
+    filters: { nodeType: { type: $nodeType } }
   ) {
-    results(size: 5, page: 0) {
+    results(size: $size, page: $page) {
       totalHits
       took
       hits {
@@ -45,24 +58,36 @@ exports[`Sort parameters tests > Query with incorrect sort field 1`] = `
         displayableName
         excerpt
         score
-        created: property(name: "jcr:created")
+        created: property(name: $created_name)
       }
     }
   }
-}"
+}",
+  "variables": {
+    "created_name": "jcr:created",
+    "functionScoreId": "fake",
+    "language": "fake",
+    "nodeType": "fake",
+    "page": 0,
+    "q": "",
+    "siteKey": "fake",
+    "size": 5,
+  },
+}
 `;
 
 exports[`Sort parameters tests > Query with sort 1`] = `
-"{
+{
+  "query": "query ($created_name: String!, $q: String!, $siteKey: String!, $language: String!, $functionScoreId: String!, $nodeType: String!, $size: Int!, $page: Int!, $sortField: String!) {
   search(
-    q: ""
-    siteKeys: ["fake"]
-    language: "fake"
+    q: $q
+    siteKeys: [$siteKey]
+    language: $language
     workspace: fake
-    functionScoreId: "fake"
-    filters: { nodeType: { type: "fake" } }
+    functionScoreId: $functionScoreId
+    filters: { nodeType: { type: $nodeType } }
   ) {
-    results(size: 5, page: 0, sortBy: { dir: ASC, field: "jcr:title" }) {
+    results(size: $size, page: $page, sortBy: { dir: ASC, field: $sortField }) {
       totalHits
       took
       hits {
@@ -71,24 +96,37 @@ exports[`Sort parameters tests > Query with sort 1`] = `
         displayableName
         excerpt
         score
-        created: property(name: "jcr:created")
+        created: property(name: $created_name)
       }
     }
   }
-}"
+}",
+  "variables": {
+    "created_name": "jcr:created",
+    "functionScoreId": "fake",
+    "language": "fake",
+    "nodeType": "fake",
+    "page": 0,
+    "q": "",
+    "siteKey": "fake",
+    "size": 5,
+    "sortField": "jcr:title",
+  },
+}
 `;
 
 exports[`Sort parameters tests > Query without sort 1`] = `
-"{
+{
+  "query": "query ($created_name: String!, $q: String!, $siteKey: String!, $language: String!, $functionScoreId: String!, $nodeType: String!, $size: Int!, $page: Int!) {
   search(
-    q: ""
-    siteKeys: ["fake"]
-    language: "fake"
+    q: $q
+    siteKeys: [$siteKey]
+    language: $language
     workspace: fake
-    functionScoreId: "fake"
-    filters: { nodeType: { type: "fake" } }
+    functionScoreId: $functionScoreId
+    filters: { nodeType: { type: $nodeType } }
   ) {
-    results(size: 5, page: 0) {
+    results(size: $size, page: $page) {
       totalHits
       took
       hits {
@@ -97,9 +135,20 @@ exports[`Sort parameters tests > Query without sort 1`] = `
         displayableName
         excerpt
         score
-        created: property(name: "jcr:created")
+        created: property(name: $created_name)
       }
     }
   }
-}"
+}",
+  "variables": {
+    "created_name": "jcr:created",
+    "functionScoreId": "fake",
+    "language": "fake",
+    "nodeType": "fake",
+    "page": 0,
+    "q": "",
+    "siteKey": "fake",
+    "size": 5,
+  },
+}
 `;

--- a/src/__tests__/adaptRequest.test.ts
+++ b/src/__tests__/adaptRequest.test.ts
@@ -1,8 +1,8 @@
 import adaptRequest from '../adaptRequest.js';
 import {Field, FieldType} from '../field.js';
 import {parse, print} from 'graphql';
-import {searchTermArgOf} from './helpers.js';
-import type {QueryConfig, RequestOptions, RequestState} from '../types.js';
+import {assertEveryVariableIsUsed, inlineVariables} from './helpers.js';
+import type {FacetConfig, QueryConfig, RequestOptions, RequestState} from '../types.js';
 
 const defaultRequestOptions: RequestOptions = {
     siteKey: 'academy',
@@ -230,7 +230,11 @@ const adaptedFilteredRequest = print(parse(`{
                         terms:[{field:"jgql:categories_path",value:"reg:markets[^/]*/.*"}]
                     }]
                     dateRange:[{operation:AND, ranges:[{field:"jgql:lastModified",after:"now-1y",before:"now"}]}],
-                    numberRange:[{operation:AND, ranges:[{field:"popularity",gte:500.0,lt:1000.0}]}]
+                    # Was gte:500.0, lt:1000.0. The bounds are configured as the strings "500.0" and
+                    # "1000.0" and used to be interpolated raw, which happened to print as a Float
+                    # literal. They are now converted and sent as numbers, so 500.0 prints as 500 —
+                    # the same value for a Float argument.
+                    numberRange:[{operation:AND, ranges:[{field:"popularity",gte:500,lt:1000}]}]
                 }
             }
       ) {
@@ -283,87 +287,126 @@ const adaptedFilteredRequest = print(parse(`{
 
 describe('adaptRequest', () => {
     test('adapts default request', () => {
-        expect(adaptRequest(defaultRequestOptions, defaultRequest, queryConfig)).toEqual(
+        expect(inlineVariables(adaptRequest(defaultRequestOptions, defaultRequest, queryConfig))).toEqual(
             adaptedDefaultRequest
         );
     });
     test('adapts nodetype request', () => {
-        expect(adaptRequest(nodeTypeRequestOptions, defaultRequest, queryConfig)).toEqual(
+        expect(inlineVariables(adaptRequest(nodeTypeRequestOptions, defaultRequest, queryConfig))).toEqual(
             adaptedNodeTypeFilterRequest
         );
     });
     test('adapts filtered request', () => {
-        expect(adaptRequest(defaultRequestOptions, requestWithFilters, queryConfig)).toEqual(
+        expect(inlineVariables(adaptRequest(defaultRequestOptions, requestWithFilters, queryConfig))).toEqual(
             adaptedFilteredRequest
         );
     });
 });
 
-/**
- * Characterization tests added ahead of a rewrite: they record what the current implementation does,
- * not what it ought to do. Cases marked KNOWN BUG pin behaviour we believe is wrong — a rewrite that
- * fixes one SHOULD fail here, and the expectation should then be updated deliberately rather than
- * the test deleted.
- */
-
 const noFieldsQueryConfig: QueryConfig = {result_fields: []};
 
-describe('adaptRequest — search term escaping', () => {
-    // `searchTerm` is deliberately looser than RequestState declares: one case below passes a
-    // number, to pin how a falsy-but-meaningful term is handled.
+/**
+ * The search term used to be HTML-escaped and interpolated into the query text. That was the only
+ * barrier against a visitor's input reaching the document, and it leaked in both directions: it
+ * mangled ordinary searches, and it did not actually stop a newline from breaking the query.
+ *
+ * The term is now a variable, so it is sent exactly as typed and never appears in the document.
+ * Each case below replaces one that pinned the old escaping.
+ */
+describe('adaptRequest — the search term is sent as a variable', () => {
+    // `searchTerm` is deliberately looser than RequestState declares: one case passes a number.
     const q = (searchTerm: unknown, request: RequestState = {}) =>
-        searchTermArgOf(adaptRequest(defaultRequestOptions, {...request, searchTerm} as RequestState, noFieldsQueryConfig));
+        adaptRequest(defaultRequestOptions, {...request, searchTerm} as RequestState, noFieldsQueryConfig).variables.q;
 
-    it('emits an empty q for an undefined search term', () => {
-        expect(searchTermArgOf(adaptRequest(defaultRequestOptions, {}, noFieldsQueryConfig))).toMatchInlineSnapshot(`"q: """`);
+    it('searches for the empty string when the term is undefined', () => {
+        expect(adaptRequest(defaultRequestOptions, {}, noFieldsQueryConfig).variables.q).toBe('');
     });
 
-    it('emits an empty q for an empty search term', () => {
-        expect(q('')).toMatchInlineSnapshot(`"q: """`);
+    it('searches for the empty string when the term is empty', () => {
+        expect(q('')).toBe('');
     });
 
-    // KNOWN BUG: htmlEscape guards on truthiness, so any falsy-but-meaningful term is discarded.
-    // A numeric search term of 0 searches for nothing rather than for "0".
-    it('discards a search term of 0 (KNOWN BUG)', () => {
-        expect(q(0)).toMatchInlineSnapshot(`"q: """`);
+    // Was a KNOWN BUG: htmlEscape guarded on truthiness, so a numeric 0 searched for nothing.
+    it('searches for "0" when the term is the number 0', () => {
+        expect(q(0)).toBe('0');
     });
 
-    it('escapes ampersands, quotes, apostrophes and angle brackets as HTML entities', () => {
-        expect(q('a&b"c\'d<e>f')).toMatchInlineSnapshot(`"q: "a&amp;b&quot;c&#39;d&lt;e&gt;f""`);
+    // Was pinned as HTML-escaping. Escaping a search term was never right — a visitor looking for
+    // `a & b` was searching for `a &amp; b`.
+    it('leaves ampersands, quotes, apostrophes and angle brackets alone', () => {
+        expect(q('a&b"c\'d<e>f')).toBe('a&b"c\'d<e>f');
     });
 
-    it('doubles a trailing backslash', () => {
-        expect(q('di\\')).toMatchInlineSnapshot(`"q: "di\\\\""`);
+    it('leaves backslashes alone rather than doubling them', () => {
+        expect(q('di\\')).toBe('di\\');
+        expect(q('di\\g\\it')).toBe('di\\g\\it');
     });
 
-    it('doubles an embedded backslash', () => {
-        expect(q('di\\g\\it')).toMatchInlineSnapshot(`"q: "di\\\\g\\\\it""`);
-    });
-
-    it('escapes in a fixed order, so an entity typed by the user is double-escaped', () => {
-        expect(q('&lt;')).toMatchInlineSnapshot(`"q: "&amp;lt;""`);
+    it('does not double-escape an entity the visitor typed', () => {
+        expect(q('&lt;')).toBe('&lt;');
     });
 
     it('leaves other characters alone', () => {
-        expect(q('café (résumé) 50% #1')).toMatchInlineSnapshot(`"q: "café (résumé) 50% #1""`);
+        expect(q('café (résumé) 50% #1')).toBe('café (résumé) 50% #1');
     });
 
-    // KNOWN BUG: newlines are not escaped, and a literal newline is illegal inside a GraphQL string
-    // literal, so the query fails to parse. Pasting multi-line text into a search box throws out of
-    // adaptRequest rather than searching.
-    it('throws on a search term containing a newline (KNOWN BUG)', () => {
-        expect(() => adaptRequest(defaultRequestOptions, {searchTerm: 'multi\nline'}, noFieldsQueryConfig))
-            .toThrow('Syntax Error: Unterminated string.');
+    // Was a KNOWN BUG: a literal newline is illegal inside a GraphQL string, so pasting multi-line
+    // text into a search box threw out of adaptRequest instead of searching.
+    it('searches for a term containing a newline instead of throwing', () => {
+        expect(q('multi\nline')).toBe('multi\nline');
+    });
+
+    it('keeps the term out of the document, whatever it contains', () => {
+        const {query, variables} = adaptRequest(
+            defaultRequestOptions,
+            {searchTerm: '") {id} evil('},
+            noFieldsQueryConfig
+        );
+        expect(query).not.toContain('evil');
+        expect(variables.q).toBe('") {id} evil(');
+    });
+});
+
+describe('adaptRequest — the workspace enum', () => {
+    // `workspace` cannot be a variable without knowing the schema's enum type name, so it is the
+    // one connector option still written into the document — and therefore checked.
+    it('rejects a workspace that is not a GraphQL enum value', () => {
+        expect(() => adaptRequest(
+            {...defaultRequestOptions, workspace: 'LIVE) {id} evil('},
+            {},
+            noFieldsQueryConfig
+        )).toThrow('workspace must be a GraphQL enum value');
+    });
+});
+
+describe('adaptRequest — every declared variable is used', () => {
+    // A variable that is declared but never referenced makes the whole query invalid, and neither
+    // parse() nor a snapshot notices. These are the configurations most likely to regress it.
+    it.each([
+        ['default', defaultRequestOptions, defaultRequest, queryConfig],
+        ['nodeType filter', nodeTypeRequestOptions, defaultRequest, queryConfig],
+        ['request filters', defaultRequestOptions, requestWithFilters, queryConfig],
+        ['no fields', defaultRequestOptions, {}, noFieldsQueryConfig],
+        ['facet with an unrecognised type', defaultRequestOptions, {}, {
+            ...noFieldsQueryConfig,
+            facets: {weird: {type: 'not-a-real-type'} as unknown as FacetConfig}
+        }],
+        ['range facet carrying a minDoc it never sends', defaultRequestOptions, {}, {
+            ...noFieldsQueryConfig,
+            facets: {popularity: {type: 'range', minDoc: 1, ranges: [{name: 'r', from: '0', to: '1'}]} as FacetConfig}
+        }]
+    ])('%s', (_name, options, request, config) => {
+        expect(() => assertEveryVariableIsUsed(adaptRequest(options, request, config))).not.toThrow();
     });
 });
 
 describe('adaptRequest — result_fields resolution', () => {
     it('ignores entries that are not Field instances', () => {
-        expect(adaptRequest(
+        expect(inlineVariables(adaptRequest(
             defaultRequestOptions,
             {},
             {result_fields: {notAField: 'link', alsoNot: null, real: new Field(FieldType.HIT, 'link')}}
-        )).toMatchInlineSnapshot(`
+        ))).toMatchInlineSnapshot(`
           "{
             search(
               q: ""
@@ -386,11 +429,11 @@ describe('adaptRequest — result_fields resolution', () => {
     });
 
     it('reads result_fields from the results wrapper when the config has one', () => {
-        expect(adaptRequest(
+        expect(inlineVariables(adaptRequest(
             defaultRequestOptions,
             {},
             {results: {result_fields: [new Field(FieldType.HIT, 'link')]}}
-        )).toMatchInlineSnapshot(`
+        ))).toMatchInlineSnapshot(`
           "{
             search(
               q: ""
@@ -414,15 +457,16 @@ describe('adaptRequest — result_fields resolution', () => {
 
     it('defaults to 5 results on page 0 when the request sets no paging', () => {
         expect(adaptRequest(defaultRequestOptions, {}, noFieldsQueryConfig)).toMatchInlineSnapshot(`
-          "{
+          {
+            "query": "query ($q: String!, $siteKey: String!, $language: String!, $functionScoreId: String!, $size: Int!, $page: Int!) {
             search(
-              q: ""
-              siteKeys: ["academy"]
-              language: "en"
+              q: $q
+              siteKeys: [$siteKey]
+              language: $language
               workspace: LIVE
-              functionScoreId: ""
+              functionScoreId: $functionScoreId
             ) {
-              results(size: 5, page: 0) {
+              results(size: $size, page: $page) {
                 totalHits
                 took
                 hits {
@@ -430,16 +474,25 @@ describe('adaptRequest — result_fields resolution', () => {
                 }
               }
             }
-          }"
+          }",
+            "variables": {
+              "functionScoreId": "",
+              "language": "en",
+              "page": 0,
+              "q": "",
+              "siteKey": "academy",
+              "size": 5,
+            },
+          }
         `);
     });
 
     it('lets the request override the request options', () => {
-        expect(adaptRequest(
+        expect(inlineVariables(adaptRequest(
             {...defaultRequestOptions, resultsPerPage: 20},
             {resultsPerPage: 3, current: 2},
             noFieldsQueryConfig
-        )).toMatchInlineSnapshot(`
+        ))).toMatchInlineSnapshot(`
           "{
             search(
               q: ""

--- a/src/__tests__/facets.test.ts
+++ b/src/__tests__/facets.test.ts
@@ -1,27 +1,37 @@
 import facets from '../facets.js';
 import {normalizeSelections} from './helpers.js';
-import type {FacetConfig, QueryConfig} from '../types.js';
+import {GraphQLVariables} from '../graphql.js';
+import type {NormalizedFragment} from './helpers.js';
+import type {FacetConfig, QueryConfig, RequestState} from '../types.js';
+
+const selectionsFor = (request: RequestState, queryConfig: QueryConfig): NormalizedFragment =>
+    normalizeSelections(v => facets(request, queryConfig, v));
+
+/** For the cases that assert on the raw fragment rather than the parsed document. */
+const fragmentFor = (request: RequestState, queryConfig: QueryConfig): string =>
+    facets(request, queryConfig, new GraphQLVariables());
 
 /**
- * Characterization tests for `facets()`, written ahead of a rewrite: they record what the current
- * implementation does, not what it ought to do. Cases marked KNOWN BUG pin behaviour we believe is
- * wrong — a rewrite that fixes one SHOULD fail here, and the expectation should then be updated
- * deliberately rather than the test deleted.
+ * Tests for `facets()`. Most began as characterization tests recording what the string-building
+ * implementation did; the cases that pinned a bug the move to variables fixed now pin the fix.
  *
- * Note for the rewrite: `extractSelections` walks `request.filters` and stores a `selections` array
- * on each processed facet, but the query-building loop below it never reads that array. It is dead
- * code, and no test here can observe it — the outputs for a request with and without filters are
- * identical (pinned by 'ignores request filters entirely').
+ * Every value is a variable, so an assertion covers both the document — which must carry nothing
+ * caller-supplied but the response key — and the values sent alongside it.
+ *
+ * `extractSelections`, which walked `request.filters` into a `selections` array that the
+ * query-building loop never read, is gone. It was dead code no test could observe, and keeping it
+ * would have meant registering variables the document never references, which invalidates a query.
+ * 'ignores request filters entirely' still pins the behaviour it was invisible to.
  */
 
 describe('facets', () => {
     describe('nothing to emit', () => {
         it('returns an empty string when the config has no facets key', () => {
-            expect(facets({}, {})).toBe('');
+            expect(fragmentFor({}, {})).toBe('');
         });
 
         it('returns an empty string when the facets config is empty', () => {
-            expect(facets({}, {facets: {}})).toBe('');
+            expect(fragmentFor({}, {facets: {}})).toBe('');
         });
 
         // The value/range branches are an if/else-if chain with no fallback, so a facet whose type
@@ -29,69 +39,109 @@ describe('facets', () => {
         // inconsistency with filters(), which treats an unknown type as a value facet: a typo in a
         // facet type yields filtering with no corresponding facet.
         it('silently drops a facet with an unrecognised type', () => {
-            expect(facets({}, {facets: {weird: {type: 'not-a-real-type'} as unknown as FacetConfig}})).toBe('');
+            expect(fragmentFor({}, {facets: {weird: {type: 'not-a-real-type'} as unknown as FacetConfig}})).toBe('');
+        });
+
+        // Dropping it must also leave no trace in the variables: a variable that is declared but
+        // never referenced makes the whole query invalid.
+        it('registers no variables for a facet it drops', () => {
+            const variables = new GraphQLVariables();
+            facets({}, {facets: {weird: {type: 'not-a-real-type'} as unknown as FacetConfig}}, variables);
+            expect(variables.values()).toEqual({});
         });
     });
 
     describe('term facets', () => {
         it('omits max and minDocCount when neither is configured', () => {
-            expect(normalizeSelections(facets({}, {facets: {'jgql:tags': {type: 'value'}}}))).toMatchInlineSnapshot(`
-              "{
+            expect(selectionsFor({}, {facets: {'jgql:tags': {type: 'value'}}})).toMatchInlineSnapshot(`
+              {
+                "query": "query ($jgql_tags_disjunctive: Boolean!, $jgql_tags_field: String!) {
                 search {
                   totalHits
-                  jgql_tags: termFacet(field: "jgql:tags", disjunctive: false) {
+                  jgql_tags: termFacet(
+                    field: $jgql_tags_field
+                    disjunctive: $jgql_tags_disjunctive
+                  ) {
                     data {
                       value
                       count
                     }
                   }
                 }
-              }"
+              }",
+                "variables": {
+                  "jgql_tags_disjunctive": false,
+                  "jgql_tags_field": "jgql:tags",
+                },
+              }
             `);
         });
 
         it('emits max only', () => {
-            expect(normalizeSelections(facets({}, {facets: {'jgql:tags': {type: 'value', max: 10}}}))).toMatchInlineSnapshot(`
-              "{
+            expect(selectionsFor({}, {facets: {'jgql:tags': {type: 'value', max: 10}}})).toMatchInlineSnapshot(`
+              {
+                "query": "query ($jgql_tags_disjunctive: Boolean!, $jgql_tags_field: String!, $jgql_tags_max: Int!) {
                 search {
                   totalHits
-                  jgql_tags: termFacet(field: "jgql:tags", disjunctive: false, max: 10) {
+                  jgql_tags: termFacet(
+                    field: $jgql_tags_field
+                    disjunctive: $jgql_tags_disjunctive
+                    max: $jgql_tags_max
+                  ) {
                     data {
                       value
                       count
                     }
                   }
                 }
-              }"
+              }",
+                "variables": {
+                  "jgql_tags_disjunctive": false,
+                  "jgql_tags_field": "jgql:tags",
+                  "jgql_tags_max": 10,
+                },
+              }
             `);
         });
 
         it('emits minDocCount only', () => {
-            expect(normalizeSelections(facets({}, {facets: {'jgql:tags': {type: 'value', minDoc: 1}}}))).toMatchInlineSnapshot(`
-              "{
+            expect(selectionsFor({}, {facets: {'jgql:tags': {type: 'value', minDoc: 1}}})).toMatchInlineSnapshot(`
+              {
+                "query": "query ($jgql_tags_disjunctive: Boolean!, $jgql_tags_field: String!, $jgql_tags_minDocCount: Int!) {
                 search {
                   totalHits
-                  jgql_tags: termFacet(field: "jgql:tags", disjunctive: false, minDocCount: 1) {
+                  jgql_tags: termFacet(
+                    field: $jgql_tags_field
+                    disjunctive: $jgql_tags_disjunctive
+                    minDocCount: $jgql_tags_minDocCount
+                  ) {
                     data {
                       value
                       count
                     }
                   }
                 }
-              }"
+              }",
+                "variables": {
+                  "jgql_tags_disjunctive": false,
+                  "jgql_tags_field": "jgql:tags",
+                  "jgql_tags_minDocCount": 1,
+                },
+              }
             `);
         });
 
         it('emits both, and coerces a missing disjunctive to false', () => {
-            expect(normalizeSelections(facets({}, {facets: {'jgql:tags': {type: 'value', max: 10, minDoc: 1}}}))).toMatchInlineSnapshot(`
-              "{
+            expect(selectionsFor({}, {facets: {'jgql:tags': {type: 'value', max: 10, minDoc: 1}}})).toMatchInlineSnapshot(`
+              {
+                "query": "query ($jgql_tags_disjunctive: Boolean!, $jgql_tags_field: String!, $jgql_tags_max: Int!, $jgql_tags_minDocCount: Int!) {
                 search {
                   totalHits
                   jgql_tags: termFacet(
-                    field: "jgql:tags"
-                    disjunctive: false
-                    max: 10
-                    minDocCount: 1
+                    field: $jgql_tags_field
+                    disjunctive: $jgql_tags_disjunctive
+                    max: $jgql_tags_max
+                    minDocCount: $jgql_tags_minDocCount
                   ) {
                     data {
                       value
@@ -99,34 +149,26 @@ describe('facets', () => {
                     }
                   }
                 }
-              }"
+              }",
+                "variables": {
+                  "jgql_tags_disjunctive": false,
+                  "jgql_tags_field": "jgql:tags",
+                  "jgql_tags_max": 10,
+                  "jgql_tags_minDocCount": 1,
+                },
+              }
             `);
         });
 
         it('emits disjunctive true', () => {
-            expect(normalizeSelections(facets({}, {facets: {'jgql:tags': {type: 'value', disjunctive: true}}}))).toMatchInlineSnapshot(`
-              "{
+            expect(selectionsFor({}, {facets: {'jgql:tags': {type: 'value', disjunctive: true}}})).toMatchInlineSnapshot(`
+              {
+                "query": "query ($jgql_tags_disjunctive: Boolean!, $jgql_tags_field: String!) {
                 search {
                   totalHits
-                  jgql_tags: termFacet(field: "jgql:tags", disjunctive: true) {
-                    data {
-                      value
-                      count
-                    }
-                  }
-                }
-              }"
-            `);
-        });
-
-        it('replaces colons and dots in the response alias but not in the field argument', () => {
-            expect(normalizeSelections(facets({}, {facets: {'jgql:categories.path': {type: 'value'}}}))).toMatchInlineSnapshot(`
-              "{
-                search {
-                  totalHits
-                  jgql_categories_path: termFacet(
-                    field: "jgql:categories.path"
-                    disjunctive: false
+                  jgql_tags: termFacet(
+                    field: $jgql_tags_field
+                    disjunctive: $jgql_tags_disjunctive
                   ) {
                     data {
                       value
@@ -134,25 +176,56 @@ describe('facets', () => {
                     }
                   }
                 }
-              }"
+              }",
+                "variables": {
+                  "jgql_tags_disjunctive": true,
+                  "jgql_tags_field": "jgql:tags",
+                },
+              }
+            `);
+        });
+
+        it('replaces colons and dots in the response alias but not in the field argument', () => {
+            expect(selectionsFor({}, {facets: {'jgql:categories.path': {type: 'value'}}})).toMatchInlineSnapshot(`
+              {
+                "query": "query ($jgql_categories_path_disjunctive: Boolean!, $jgql_categories_path_field: String!) {
+                search {
+                  totalHits
+                  jgql_categories_path: termFacet(
+                    field: $jgql_categories_path_field
+                    disjunctive: $jgql_categories_path_disjunctive
+                  ) {
+                    data {
+                      value
+                      count
+                    }
+                  }
+                }
+              }",
+                "variables": {
+                  "jgql_categories_path_disjunctive": false,
+                  "jgql_categories_path_field": "jgql:categories.path",
+                },
+              }
             `);
         });
     });
 
     describe('tree facets', () => {
         it('emits rootPath, max and minDocCount', () => {
-            expect(normalizeSelections(facets({}, {
+            expect(selectionsFor({}, {
                 facets: {'jgql:categories_path': {type: 'value', hierarchical: true, rootPath: '/sites', max: 50, minDoc: 1, disjunctive: true}}
-            }))).toMatchInlineSnapshot(`
-              "{
+            })).toMatchInlineSnapshot(`
+              {
+                "query": "query ($jgql_categories_path_rootPath: String!, $jgql_categories_path_disjunctive: Boolean!, $jgql_categories_path_field: String!, $jgql_categories_path_max: Int!, $jgql_categories_path_minDocCount: Int!) {
                 search {
                   totalHits
                   jgql_categories_path: treeFacet(
-                    field: "jgql:categories_path"
-                    rootPath: "/sites"
-                    disjunctive: true
-                    max: 50
-                    minDocCount: 1
+                    field: $jgql_categories_path_field
+                    rootPath: $jgql_categories_path_rootPath
+                    disjunctive: $jgql_categories_path_disjunctive
+                    max: $jgql_categories_path_max
+                    minDocCount: $jgql_categories_path_minDocCount
                   ) {
                     data {
                       value
@@ -164,20 +237,28 @@ describe('facets', () => {
                     }
                   }
                 }
-              }"
+              }",
+                "variables": {
+                  "jgql_categories_path_disjunctive": true,
+                  "jgql_categories_path_field": "jgql:categories_path",
+                  "jgql_categories_path_max": 50,
+                  "jgql_categories_path_minDocCount": 1,
+                  "jgql_categories_path_rootPath": "/sites",
+                },
+              }
             `);
         });
 
-        // KNOWN BUG: rootPath is interpolated with no guard, so an unset rootPath is sent to the
-        // backend as the literal string "undefined".
-        it('sends the string "undefined" when rootPath is unset (KNOWN BUG)', () => {
-            const fragment = facets({}, {facets: {c: {type: 'value', hierarchical: true}}});
-            expect(fragment).toContain('rootPath: "undefined"');
-            expect(normalizeSelections(fragment)).toMatchInlineSnapshot(`
-              "{
+        // Was a KNOWN BUG: rootPath used to be interpolated with no guard, so an unset one reached
+        // the backend as the literal string "undefined". The argument is now left out entirely —
+        // it cannot be sent as null, because the variables are declared non-null.
+        it('omits rootPath when it is unset', () => {
+            expect(selectionsFor({}, {facets: {c: {type: 'value', hierarchical: true}}})).toMatchInlineSnapshot(`
+              {
+                "query": "query ($c_disjunctive: Boolean!, $c_field: String!) {
                 search {
                   totalHits
-                  c: treeFacet(field: "c", rootPath: "undefined", disjunctive: false) {
+                  c: treeFacet(field: $c_field, disjunctive: $c_disjunctive) {
                     data {
                       value
                       count
@@ -188,23 +269,34 @@ describe('facets', () => {
                     }
                   }
                 }
-              }"
+              }",
+                "variables": {
+                  "c_disjunctive": false,
+                  "c_field": "c",
+                },
+              }
             `);
         });
 
         it('only treats hierarchical === true as a tree facet', () => {
-            expect(normalizeSelections(facets({}, {facets: {c: {type: 'value', hierarchical: 'yes'} as unknown as FacetConfig}}))).toMatchInlineSnapshot(`
-              "{
+            expect(selectionsFor({}, {facets: {c: {type: 'value', hierarchical: 'yes'} as unknown as FacetConfig}})).toMatchInlineSnapshot(`
+              {
+                "query": "query ($c_disjunctive: Boolean!, $c_field: String!) {
                 search {
                   totalHits
-                  c: termFacet(field: "c", disjunctive: false) {
+                  c: termFacet(field: $c_field, disjunctive: $c_disjunctive) {
                     data {
                       value
                       count
                     }
                   }
                 }
-              }"
+              }",
+                "variables": {
+                  "c_disjunctive": false,
+                  "c_field": "c",
+                },
+              }
             `);
         });
     });
@@ -216,15 +308,16 @@ describe('facets', () => {
         ];
 
         it('emits ranges without max', () => {
-            expect(normalizeSelections(facets({}, {facets: {popularity: {type: 'range', ranges}}}))).toMatchInlineSnapshot(`
-              "{
+            expect(selectionsFor({}, {facets: {popularity: {type: 'range', ranges}}})).toMatchInlineSnapshot(`
+              {
+                "query": "query ($popularity_0_name: String!, $popularity_0_from: String!, $popularity_0_to: String!, $popularity_1_name: String!, $popularity_1_from: String!, $popularity_1_to: String!, $popularity_field: String!) {
                 search {
                   totalHits
                   popularity: rangeFacet(
-                    field: "popularity"
+                    field: $popularity_field
                     ranges: [
-                      { name: "low", from: "0.0", to: "500.0" }
-                      { name: "high", from: "500.0", to: "1000.0" }
+                      { name: $popularity_0_name, from: $popularity_0_from, to: $popularity_0_to }
+                      { name: $popularity_1_name, from: $popularity_1_from, to: $popularity_1_to }
                     ]
                   ) {
                     data {
@@ -233,22 +326,33 @@ describe('facets', () => {
                     }
                   }
                 }
-              }"
+              }",
+                "variables": {
+                  "popularity_0_from": "0.0",
+                  "popularity_0_name": "low",
+                  "popularity_0_to": "500.0",
+                  "popularity_1_from": "500.0",
+                  "popularity_1_name": "high",
+                  "popularity_1_to": "1000.0",
+                  "popularity_field": "popularity",
+                },
+              }
             `);
         });
 
         it('emits ranges with max', () => {
-            expect(normalizeSelections(facets({}, {facets: {popularity: {type: 'range', ranges, max: 7}}}))).toMatchInlineSnapshot(`
-              "{
+            expect(selectionsFor({}, {facets: {popularity: {type: 'range', ranges, max: 7}}})).toMatchInlineSnapshot(`
+              {
+                "query": "query ($popularity_0_name: String!, $popularity_0_from: String!, $popularity_0_to: String!, $popularity_1_name: String!, $popularity_1_from: String!, $popularity_1_to: String!, $popularity_field: String!, $popularity_max: Int!) {
                 search {
                   totalHits
                   popularity: rangeFacet(
-                    field: "popularity"
+                    field: $popularity_field
                     ranges: [
-                      { name: "low", from: "0.0", to: "500.0" }
-                      { name: "high", from: "500.0", to: "1000.0" }
+                      { name: $popularity_0_name, from: $popularity_0_from, to: $popularity_0_to }
+                      { name: $popularity_1_name, from: $popularity_1_from, to: $popularity_1_to }
                     ]
-                    max: 7
+                    max: $popularity_max
                   ) {
                     data {
                       name
@@ -256,20 +360,38 @@ describe('facets', () => {
                     }
                   }
                 }
-              }"
+              }",
+                "variables": {
+                  "popularity_0_from": "0.0",
+                  "popularity_0_name": "low",
+                  "popularity_0_to": "500.0",
+                  "popularity_1_from": "500.0",
+                  "popularity_1_name": "high",
+                  "popularity_1_to": "1000.0",
+                  "popularity_field": "popularity",
+                  "popularity_max": 7,
+                },
+              }
             `);
         });
 
         it('emits a date_range facet the same way', () => {
-            expect(normalizeSelections(facets({}, {
+            expect(selectionsFor({}, {
                 facets: {'jgql:lastModified': {type: 'date_range', ranges: [{from: 'now-1y', to: 'now', name: 'last year'}]}}
-            }))).toMatchInlineSnapshot(`
-              "{
+            })).toMatchInlineSnapshot(`
+              {
+                "query": "query ($jgql_lastModified_0_name: String!, $jgql_lastModified_0_from: String!, $jgql_lastModified_0_to: String!, $jgql_lastModified_field: String!) {
                 search {
                   totalHits
                   jgql_lastModified: rangeFacet(
-                    field: "jgql:lastModified"
-                    ranges: [{ name: "last year", from: "now-1y", to: "now" }]
+                    field: $jgql_lastModified_field
+                    ranges: [
+                      {
+                        name: $jgql_lastModified_0_name
+                        from: $jgql_lastModified_0_from
+                        to: $jgql_lastModified_0_to
+                      }
+                    ]
                   ) {
                     data {
                       name
@@ -277,20 +399,31 @@ describe('facets', () => {
                     }
                   }
                 }
-              }"
+              }",
+                "variables": {
+                  "jgql_lastModified_0_from": "now-1y",
+                  "jgql_lastModified_0_name": "last year",
+                  "jgql_lastModified_0_to": "now",
+                  "jgql_lastModified_field": "jgql:lastModified",
+                },
+              }
             `);
         });
 
         it('emits a range with only a from, and one with only a to', () => {
-            expect(normalizeSelections(facets({}, {
+            expect(selectionsFor({}, {
                 facets: {popularity: {type: 'range', ranges: [{from: '500.0', name: 'from only'}, {to: '500.0', name: 'to only'}]}}
-            }))).toMatchInlineSnapshot(`
-              "{
+            })).toMatchInlineSnapshot(`
+              {
+                "query": "query ($popularity_0_name: String!, $popularity_0_from: String!, $popularity_1_name: String!, $popularity_1_to: String!, $popularity_field: String!) {
                 search {
                   totalHits
                   popularity: rangeFacet(
-                    field: "popularity"
-                    ranges: [{ name: "from only", from: "500.0" }, { name: "to only", to: "500.0" }]
+                    field: $popularity_field
+                    ranges: [
+                      { name: $popularity_0_name, from: $popularity_0_from }
+                      { name: $popularity_1_name, to: $popularity_1_to }
+                    ]
                   ) {
                     data {
                       name
@@ -298,23 +431,33 @@ describe('facets', () => {
                     }
                   }
                 }
-              }"
+              }",
+                "variables": {
+                  "popularity_0_from": "500.0",
+                  "popularity_0_name": "from only",
+                  "popularity_1_name": "to only",
+                  "popularity_1_to": "500.0",
+                  "popularity_field": "popularity",
+                },
+              }
             `);
         });
 
-        // KNOWN BUG: buildRangeValue tests `range.from` / `range.to` for truthiness rather than for
-        // presence, so a numeric bound of 0 is dropped from the query — `{from: 0, to: 100}` becomes
-        // an open-ended range. String '0.0' is unaffected, which is why the fixtures above hide it.
-        it('drops a numeric bound of 0 (KNOWN BUG)', () => {
-            expect(normalizeSelections(facets({}, {
+        // Was a KNOWN BUG: buildRangeValue tested the bounds for truthiness rather than presence, so
+        // `{from: 0, to: 100}` lost its lower bound and became an open-ended range. Deciding whether
+        // to send an argument is now a presence check, because a variable cannot carry an absent
+        // value — so 0 is a bound like any other.
+        it('keeps a numeric bound of 0', () => {
+            expect(selectionsFor({}, {
                 facets: {popularity: {type: 'range', ranges: [{from: 0, to: 100, name: 'first hundred'}]}}
-            }))).toMatchInlineSnapshot(`
-              "{
+            })).toMatchInlineSnapshot(`
+              {
+                "query": "query ($popularity_0_name: String!, $popularity_0_from: String!, $popularity_0_to: String!, $popularity_field: String!) {
                 search {
                   totalHits
                   popularity: rangeFacet(
-                    field: "popularity"
-                    ranges: [{ name: "first hundred", to: "100" }]
+                    field: $popularity_field
+                    ranges: [{ name: $popularity_0_name, from: $popularity_0_from, to: $popularity_0_to }]
                   ) {
                     data {
                       name
@@ -322,41 +465,59 @@ describe('facets', () => {
                     }
                   }
                 }
-              }"
+              }",
+                "variables": {
+                  "popularity_0_from": "0",
+                  "popularity_0_name": "first hundred",
+                  "popularity_0_to": "100",
+                  "popularity_field": "popularity",
+                },
+              }
             `);
         });
     });
 
     describe('multiple facets', () => {
         it('groups by type and emits value facets before range facets', () => {
-            expect(normalizeSelections(facets({}, {
+            expect(selectionsFor({}, {
                 facets: {
                     popularity: {type: 'range', ranges: [{from: '0.0', to: '1.0', name: 'r'}]},
                     'jgql:tags': {type: 'value', max: 10},
                     'jgql:lastModified': {type: 'date_range', ranges: [{from: 'now-1y', to: 'now', name: 'd'}]}
                 }
-            }))).toMatchInlineSnapshot(`
-              "{
+            })).toMatchInlineSnapshot(`
+              {
+                "query": "query ($popularity_0_name: String!, $popularity_0_from: String!, $popularity_0_to: String!, $popularity_field: String!, $jgql_tags_disjunctive: Boolean!, $jgql_tags_field: String!, $jgql_tags_max: Int!, $jgql_lastModified_0_name: String!, $jgql_lastModified_0_from: String!, $jgql_lastModified_0_to: String!, $jgql_lastModified_field: String!) {
                 search {
                   totalHits
                   popularity: rangeFacet(
-                    field: "popularity"
-                    ranges: [{ name: "r", from: "0.0", to: "1.0" }]
+                    field: $popularity_field
+                    ranges: [{ name: $popularity_0_name, from: $popularity_0_from, to: $popularity_0_to }]
                   ) {
                     data {
                       name
                       count
                     }
                   }
-                  jgql_tags: termFacet(field: "jgql:tags", disjunctive: false, max: 10) {
+                  jgql_tags: termFacet(
+                    field: $jgql_tags_field
+                    disjunctive: $jgql_tags_disjunctive
+                    max: $jgql_tags_max
+                  ) {
                     data {
                       value
                       count
                     }
                   }
                   jgql_lastModified: rangeFacet(
-                    field: "jgql:lastModified"
-                    ranges: [{ name: "d", from: "now-1y", to: "now" }]
+                    field: $jgql_lastModified_field
+                    ranges: [
+                      {
+                        name: $jgql_lastModified_0_name
+                        from: $jgql_lastModified_0_from
+                        to: $jgql_lastModified_0_to
+                      }
+                    ]
                   ) {
                     data {
                       name
@@ -364,14 +525,30 @@ describe('facets', () => {
                     }
                   }
                 }
-              }"
+              }",
+                "variables": {
+                  "jgql_lastModified_0_from": "now-1y",
+                  "jgql_lastModified_0_name": "d",
+                  "jgql_lastModified_0_to": "now",
+                  "jgql_lastModified_field": "jgql:lastModified",
+                  "jgql_tags_disjunctive": false,
+                  "jgql_tags_field": "jgql:tags",
+                  "jgql_tags_max": 10,
+                  "popularity_0_from": "0.0",
+                  "popularity_0_name": "r",
+                  "popularity_0_to": "1.0",
+                  "popularity_field": "popularity",
+                },
+              }
             `);
         });
 
+        // Both the document and the values it asks for: a request's filters must not leak into the
+        // facet query in either form.
         it('ignores request filters entirely', () => {
             const config: QueryConfig = {facets: {'jgql:tags': {type: 'value', max: 10}}};
-            const withFilters = facets({filters: [{field: 'jgql:tags', values: ['Action'], type: 'all'}]}, config);
-            expect(withFilters).toBe(facets({}, config));
+            const withFilters = selectionsFor({filters: [{field: 'jgql:tags', values: ['Action'], type: 'all'}]}, config);
+            expect(withFilters).toEqual(selectionsFor({}, config));
         });
     });
 });

--- a/src/__tests__/filters.test.ts
+++ b/src/__tests__/filters.test.ts
@@ -1,13 +1,29 @@
 import filters from '../filters.js';
 import {normalizeArgs} from './helpers.js';
-import type {FacetConfig, QueryConfig} from '../types.js';
+import {GraphQLVariables} from '../graphql.js';
+import type {NormalizedFragment} from './helpers.js';
+import type {FacetConfig, QueryConfig, RequestState} from '../types.js';
 
 /**
- * Characterization tests for `filters()`, written ahead of a rewrite: they record what the current
- * implementation does, not what it ought to do. Cases that pin behaviour we believe is wrong are
- * marked KNOWN BUG — a rewrite that fixes one of them SHOULD fail here, and the expectation should
- * then be updated deliberately rather than the test deleted.
+ * Tests for `filters()`. Most began as characterization tests recording what the string-building
+ * implementation did; the cases that pinned an injection bug now pin the fix, and say so.
+ *
+ * Every value is a variable, so an assertion covers two things: the document, which must carry no
+ * caller-supplied text at all, and the values sent alongside it.
  */
+
+const argsFor = (
+    request: RequestState,
+    queryConfig: QueryConfig,
+    options: {nodeType?: string}
+): NormalizedFragment => normalizeArgs(v => filters(request, queryConfig, options, v));
+
+/** For the few cases that assert on the raw fragment rather than the parsed document. */
+const fragmentFor = (
+    request: RequestState,
+    queryConfig: QueryConfig,
+    options: {nodeType?: string}
+): string => filters(request, queryConfig, options, new GraphQLVariables());
 
 const rangeFacetConfig: QueryConfig = {
     facets: {
@@ -38,20 +54,25 @@ const valueFacetConfig: QueryConfig = {facets: {'jgql:tags': {type: 'value'}}};
 describe('filters', () => {
     describe('no filters produced', () => {
         it('returns an empty string with no nodeType and no request filters', () => {
-            expect(filters({}, {facets: {}}, {})).toBe('');
+            expect(fragmentFor({}, {facets: {}}, {})).toBe('');
         });
 
         it('returns an empty string when request.filters is an empty array', () => {
-            expect(filters({filters: []}, {facets: {}}, {})).toBe('');
+            expect(fragmentFor({filters: []}, {facets: {}}, {})).toBe('');
         });
 
         it('emits only the nodeType filter when there are no request filters', () => {
-            expect(normalizeArgs(filters({}, {facets: {}}, {nodeType: 'jnt:page'}))).toMatchInlineSnapshot(`
-              "{
-                search(q: "", filters: { nodeType: { type: "jnt:page" } }) {
+            expect(argsFor({}, {facets: {}}, {nodeType: 'jnt:page'})).toMatchInlineSnapshot(`
+              {
+                "query": "query ($nodeType: String!) {
+                search(q: "", filters: { nodeType: { type: $nodeType } }) {
                   totalHits
                 }
-              }"
+              }",
+                "variables": {
+                  "nodeType": "jnt:page",
+                },
+              }
             `);
         });
     });
@@ -61,113 +82,174 @@ describe('filters', () => {
         // filter.values; this one indexes it. Selecting two values on an undeclared field silently
         // drops all but the first.
         it('keeps only the first value (KNOWN BUG)', () => {
-            expect(normalizeArgs(filters(
+            expect(argsFor(
                 {filters: [{field: 'jgql:author', values: ['alice', 'bob'], type: 'any'}]},
                 {facets: {}},
                 {}
-            ))).toMatchInlineSnapshot(`
-              "{
-                search(
-                  q: ""
-                  filters: {
-                    custom: { term: [{ operation: OR, terms: [{ field: "jgql:author", value: "alice" }] }] }
-                  }
-                ) {
-                  totalHits
-                }
-              }"
-            `);
-        });
-
-        it('maps type "any" to OR', () => {
-            expect(normalizeArgs(filters(
-                {filters: [{field: 'jgql:author', values: ['alice'], type: 'any'}]},
-                {facets: {}},
-                {}
-            ))).toMatchInlineSnapshot(`
-              "{
-                search(
-                  q: ""
-                  filters: {
-                    custom: { term: [{ operation: OR, terms: [{ field: "jgql:author", value: "alice" }] }] }
-                  }
-                ) {
-                  totalHits
-                }
-              }"
-            `);
-        });
-
-        it('maps any other type to AND', () => {
-            expect(normalizeArgs(filters(
-                {filters: [{field: 'jgql:author', values: ['alice'], type: 'all'}]},
-                {facets: {}},
-                {}
-            ))).toMatchInlineSnapshot(`
-              "{
-                search(
-                  q: ""
-                  filters: {
-                    custom: {
-                      term: [{ operation: AND, terms: [{ field: "jgql:author", value: "alice" }] }]
-                    }
-                  }
-                ) {
-                  totalHits
-                }
-              }"
-            `);
-        });
-
-        it('emits one term group per field', () => {
-            expect(normalizeArgs(filters(
-                {filters: [
-                    {field: 'jgql:author', values: ['alice'], type: 'all'},
-                    {field: 'jgql:lang', values: ['fr'], type: 'any'}
-                ]},
-                {facets: {}},
-                {}
-            ))).toMatchInlineSnapshot(`
-              "{
+            )).toMatchInlineSnapshot(`
+              {
+                "query": "query ($jgql_author_field: String!, $jgql_author_value: String!) {
                 search(
                   q: ""
                   filters: {
                     custom: {
                       term: [
-                        { operation: AND, terms: [{ field: "jgql:author", value: "alice" }] }
-                        { operation: OR, terms: [{ field: "jgql:lang", value: "fr" }] }
+                        {
+                          operation: OR
+                          terms: [{ field: $jgql_author_field, value: $jgql_author_value }]
+                        }
                       ]
                     }
                   }
                 ) {
                   totalHits
                 }
-              }"
+              }",
+                "variables": {
+                  "jgql_author_field": "jgql:author",
+                  "jgql_author_value": "alice",
+                },
+              }
             `);
         });
 
-        // KNOWN BUG: filter values are interpolated into the GraphQL string with no escaping, so a
-        // quote in a value produces a query that cannot be parsed. Unlike the search term (which
-        // goes through htmlEscape) there is no barrier here at all.
-        it('does not escape quotes in values, producing an unparseable query (KNOWN BUG)', () => {
-            const fragment = filters(
+        it('maps type "any" to OR', () => {
+            expect(argsFor(
+                {filters: [{field: 'jgql:author', values: ['alice'], type: 'any'}]},
+                {facets: {}},
+                {}
+            )).toMatchInlineSnapshot(`
+              {
+                "query": "query ($jgql_author_field: String!, $jgql_author_value: String!) {
+                search(
+                  q: ""
+                  filters: {
+                    custom: {
+                      term: [
+                        {
+                          operation: OR
+                          terms: [{ field: $jgql_author_field, value: $jgql_author_value }]
+                        }
+                      ]
+                    }
+                  }
+                ) {
+                  totalHits
+                }
+              }",
+                "variables": {
+                  "jgql_author_field": "jgql:author",
+                  "jgql_author_value": "alice",
+                },
+              }
+            `);
+        });
+
+        it('maps any other type to AND', () => {
+            expect(argsFor(
+                {filters: [{field: 'jgql:author', values: ['alice'], type: 'all'}]},
+                {facets: {}},
+                {}
+            )).toMatchInlineSnapshot(`
+              {
+                "query": "query ($jgql_author_field: String!, $jgql_author_value: String!) {
+                search(
+                  q: ""
+                  filters: {
+                    custom: {
+                      term: [
+                        {
+                          operation: AND
+                          terms: [{ field: $jgql_author_field, value: $jgql_author_value }]
+                        }
+                      ]
+                    }
+                  }
+                ) {
+                  totalHits
+                }
+              }",
+                "variables": {
+                  "jgql_author_field": "jgql:author",
+                  "jgql_author_value": "alice",
+                },
+              }
+            `);
+        });
+
+        it('emits one term group per field', () => {
+            expect(argsFor(
+                {filters: [
+                    {field: 'jgql:author', values: ['alice'], type: 'all'},
+                    {field: 'jgql:lang', values: ['fr'], type: 'any'}
+                ]},
+                {facets: {}},
+                {}
+            )).toMatchInlineSnapshot(`
+              {
+                "query": "query ($jgql_author_field: String!, $jgql_author_value: String!, $jgql_lang_field: String!, $jgql_lang_value: String!) {
+                search(
+                  q: ""
+                  filters: {
+                    custom: {
+                      term: [
+                        {
+                          operation: AND
+                          terms: [{ field: $jgql_author_field, value: $jgql_author_value }]
+                        }
+                        { operation: OR, terms: [{ field: $jgql_lang_field, value: $jgql_lang_value }] }
+                      ]
+                    }
+                  }
+                ) {
+                  totalHits
+                }
+              }",
+                "variables": {
+                  "jgql_author_field": "jgql:author",
+                  "jgql_author_value": "alice",
+                  "jgql_lang_field": "jgql:lang",
+                  "jgql_lang_value": "fr",
+                },
+              }
+            `);
+        });
+
+        // Was a KNOWN BUG: values used to be interpolated into the query with no escaping at all, so
+        // a quote produced a document that could not even be parsed. The value is now a variable,
+        // so it reaches the server verbatim and never touches the document.
+        it('sends a value containing a quote as a variable, verbatim', () => {
+            const {query, variables} = argsFor(
                 {filters: [{field: 'jgql:author', values: ['a"b'], type: 'any'}]},
                 {facets: {}},
                 {}
             );
-            expect(fragment).toContain('value:"a"b"');
-            expect(() => normalizeArgs(fragment)).toThrow('Syntax Error: Unterminated string.');
+            expect(query).not.toContain('a"b');
+            expect(variables).toEqual({'jgql_author_field': 'jgql:author', 'jgql_author_value': 'a"b'});
+        });
+
+        // The same holds for input that used to be able to close an argument list and append to the
+        // query. There is no longer any path from a filter value into the document text.
+        it('cannot break out of the query, whatever the value contains', () => {
+            const {query, variables} = argsFor(
+                {filters: [{field: 'jgql:author', values: ['") {id} evil('], type: 'any'}]},
+                {facets: {}},
+                {}
+            );
+            expect(query).not.toContain('evil');
+            expect(variables['jgql_author_value']).toBe('") {id} evil(');
         });
     });
 
     describe('value facets', () => {
         it('emits every selected value as a term', () => {
-            expect(normalizeArgs(filters(
+            expect(argsFor(
                 {filters: [{field: 'jgql:tags', values: ['Action', 'Adventure'], type: 'all'}]},
                 valueFacetConfig,
                 {}
-            ))).toMatchInlineSnapshot(`
-              "{
+            )).toMatchInlineSnapshot(`
+              {
+                "query": "query ($jgql_tags_field: String!, $jgql_tags_value: String!, $jgql_tags_field_2: String!, $jgql_tags_value_2: String!) {
                 search(
                   q: ""
                   filters: {
@@ -176,8 +258,8 @@ describe('filters', () => {
                         {
                           operation: AND
                           terms: [
-                            { field: "jgql:tags", value: "Action" }
-                            { field: "jgql:tags", value: "Adventure" }
+                            { field: $jgql_tags_field, value: $jgql_tags_value }
+                            { field: $jgql_tags_field_2, value: $jgql_tags_value_2 }
                           ]
                         }
                       ]
@@ -186,17 +268,25 @@ describe('filters', () => {
                 ) {
                   totalHits
                 }
-              }"
+              }",
+                "variables": {
+                  "jgql_tags_field": "jgql:tags",
+                  "jgql_tags_field_2": "jgql:tags",
+                  "jgql_tags_value": "Action",
+                  "jgql_tags_value_2": "Adventure",
+                },
+              }
             `);
         });
 
         it('treats an unrecognised facet type as a value facet', () => {
-            expect(normalizeArgs(filters(
+            expect(argsFor(
                 {filters: [{field: 'weird', values: ['x', 'y'], type: 'any'}]},
                 {facets: {weird: {type: 'not-a-real-type'} as unknown as FacetConfig}},
                 {}
-            ))).toMatchInlineSnapshot(`
-              "{
+            )).toMatchInlineSnapshot(`
+              {
+                "query": "query ($weird_field: String!, $weird_value: String!, $weird_field_2: String!, $weird_value_2: String!) {
                 search(
                   q: ""
                   filters: {
@@ -204,7 +294,10 @@ describe('filters', () => {
                       term: [
                         {
                           operation: OR
-                          terms: [{ field: "weird", value: "x" }, { field: "weird", value: "y" }]
+                          terms: [
+                            { field: $weird_field, value: $weird_value }
+                            { field: $weird_field_2, value: $weird_value_2 }
+                          ]
                         }
                       ]
                     }
@@ -212,40 +305,60 @@ describe('filters', () => {
                 ) {
                   totalHits
                 }
-              }"
+              }",
+                "variables": {
+                  "weird_field": "weird",
+                  "weird_field_2": "weird",
+                  "weird_value": "x",
+                  "weird_value_2": "y",
+                },
+              }
             `);
         });
     });
 
     describe('range facets', () => {
         it('emits a single selected range', () => {
-            expect(normalizeArgs(filters(
+            expect(argsFor(
                 {filters: [{field: 'popularity', values: ['high'], type: 'any'}]},
                 rangeFacetConfig,
                 {}
-            ))).toMatchInlineSnapshot(`
-              "{
+            )).toMatchInlineSnapshot(`
+              {
+                "query": "query ($popularity_field: String!, $popularity_gte: Float!, $popularity_lt: Float!) {
                 search(
                   q: ""
                   filters: {
                     custom: {
-                      numberRange: [{ operation: AND, ranges: [{ field: "popularity", gte: 500.0, lt: 1000.0 }] }]
+                      numberRange: [
+                        {
+                          operation: AND
+                          ranges: [{ field: $popularity_field, gte: $popularity_gte, lt: $popularity_lt }]
+                        }
+                      ]
                     }
                   }
                 ) {
                   totalHits
                 }
-              }"
+              }",
+                "variables": {
+                  "popularity_field": "popularity",
+                  "popularity_gte": 500,
+                  "popularity_lt": 1000,
+                },
+              }
             `);
         });
 
         it('accumulates several selected ranges on the same field', () => {
-            expect(normalizeArgs(filters(
+            expect(argsFor(
                 {filters: [{field: 'popularity', values: ['low', 'high'], type: 'any'}]},
                 rangeFacetConfig,
                 {}
-            ))).toMatchInlineSnapshot(`
-              "{
+            )).toMatchInlineSnapshot(`
+              {
+                "query": "query ($popularity_field: String!, $popularity_gte: Float!, $popularity_lt: Float!, $popularity_field_2: String!, $popularity_gte_2: Float!, $popularity_lt_2: Float!) {
                 search(
                   q: ""
                   filters: {
@@ -254,8 +367,8 @@ describe('filters', () => {
                         {
                           operation: AND
                           ranges: [
-                            { field: "popularity", gte: 0.0, lt: 500.0 }
-                            { field: "popularity", gte: 500.0, lt: 1000.0 }
+                            { field: $popularity_field, gte: $popularity_gte, lt: $popularity_lt }
+                            { field: $popularity_field_2, gte: $popularity_gte_2, lt: $popularity_lt_2 }
                           ]
                         }
                       ]
@@ -264,14 +377,23 @@ describe('filters', () => {
                 ) {
                   totalHits
                 }
-              }"
+              }",
+                "variables": {
+                  "popularity_field": "popularity",
+                  "popularity_field_2": "popularity",
+                  "popularity_gte": 0,
+                  "popularity_gte_2": 500,
+                  "popularity_lt": 500,
+                  "popularity_lt_2": 1000,
+                },
+              }
             `);
         });
 
         // KNOWN BUG: the selected value is looked up in facet.ranges with no miss handling, so a
         // stale or unknown range name crashes instead of being ignored.
         it('throws when the selected range is not in the config (KNOWN BUG)', () => {
-            expect(() => filters(
+            expect(() => fragmentFor(
                 {filters: [{field: 'popularity', values: ['does-not-exist'], type: 'any'}]},
                 rangeFacetConfig,
                 {}
@@ -281,38 +403,13 @@ describe('filters', () => {
 
     describe('date_range facets', () => {
         it('emits a single selected range', () => {
-            expect(normalizeArgs(filters(
+            expect(argsFor(
                 {filters: [{field: 'jgql:lastModified', values: ['last year'], type: 'any'}]},
                 dateRangeFacetConfig,
                 {}
-            ))).toMatchInlineSnapshot(`
-              "{
-                search(
-                  q: ""
-                  filters: {
-                    custom: {
-                      dateRange: [
-                        {
-                          operation: AND
-                          ranges: [{ field: "jgql:lastModified", after: "now-1y", before: "now" }]
-                        }
-                      ]
-                    }
-                  }
-                ) {
-                  totalHits
-                }
-              }"
-            `);
-        });
-
-        it('accumulates several selected ranges on the same field', () => {
-            expect(normalizeArgs(filters(
-                {filters: [{field: 'jgql:lastModified', values: ['last year', 'last 5 years'], type: 'any'}]},
-                dateRangeFacetConfig,
-                {}
-            ))).toMatchInlineSnapshot(`
-              "{
+            )).toMatchInlineSnapshot(`
+              {
+                "query": "query ($jgql_lastModified_field: String!, $jgql_lastModified_after: String!, $jgql_lastModified_before: String!) {
                 search(
                   q: ""
                   filters: {
@@ -321,8 +418,11 @@ describe('filters', () => {
                         {
                           operation: AND
                           ranges: [
-                            { field: "jgql:lastModified", after: "now-1y", before: "now" }
-                            { field: "jgql:lastModified", after: "now-5y", before: "now-1y" }
+                            {
+                              field: $jgql_lastModified_field
+                              after: $jgql_lastModified_after
+                              before: $jgql_lastModified_before
+                            }
                           ]
                         }
                       ]
@@ -331,13 +431,66 @@ describe('filters', () => {
                 ) {
                   totalHits
                 }
-              }"
+              }",
+                "variables": {
+                  "jgql_lastModified_after": "now-1y",
+                  "jgql_lastModified_before": "now",
+                  "jgql_lastModified_field": "jgql:lastModified",
+                },
+              }
+            `);
+        });
+
+        it('accumulates several selected ranges on the same field', () => {
+            expect(argsFor(
+                {filters: [{field: 'jgql:lastModified', values: ['last year', 'last 5 years'], type: 'any'}]},
+                dateRangeFacetConfig,
+                {}
+            )).toMatchInlineSnapshot(`
+              {
+                "query": "query ($jgql_lastModified_field: String!, $jgql_lastModified_after: String!, $jgql_lastModified_before: String!, $jgql_lastModified_field_2: String!, $jgql_lastModified_after_2: String!, $jgql_lastModified_before_2: String!) {
+                search(
+                  q: ""
+                  filters: {
+                    custom: {
+                      dateRange: [
+                        {
+                          operation: AND
+                          ranges: [
+                            {
+                              field: $jgql_lastModified_field
+                              after: $jgql_lastModified_after
+                              before: $jgql_lastModified_before
+                            }
+                            {
+                              field: $jgql_lastModified_field_2
+                              after: $jgql_lastModified_after_2
+                              before: $jgql_lastModified_before_2
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  }
+                ) {
+                  totalHits
+                }
+              }",
+                "variables": {
+                  "jgql_lastModified_after": "now-1y",
+                  "jgql_lastModified_after_2": "now-5y",
+                  "jgql_lastModified_before": "now",
+                  "jgql_lastModified_before_2": "now-1y",
+                  "jgql_lastModified_field": "jgql:lastModified",
+                  "jgql_lastModified_field_2": "jgql:lastModified",
+                },
+              }
             `);
         });
 
         // KNOWN BUG: same missing-range crash as the numeric case above.
         it('throws when the selected range is not in the config (KNOWN BUG)', () => {
-            expect(() => filters(
+            expect(() => fragmentFor(
                 {filters: [{field: 'jgql:lastModified', values: ['does-not-exist'], type: 'any'}]},
                 dateRangeFacetConfig,
                 {}
@@ -356,39 +509,21 @@ describe('filters', () => {
         };
 
         it('omits dateRange and numberRange when only terms are selected', () => {
-            expect(normalizeArgs(filters(
+            expect(argsFor(
                 {filters: [{field: 'jgql:tags', values: ['Action'], type: 'all'}]},
                 config,
                 {}
-            ))).toMatchInlineSnapshot(`
-              "{
-                search(
-                  q: ""
-                  filters: {
-                    custom: { term: [{ operation: AND, terms: [{ field: "jgql:tags", value: "Action" }] }] }
-                  }
-                ) {
-                  totalHits
-                }
-              }"
-            `);
-        });
-
-        it('omits term and numberRange when only a date range is selected', () => {
-            expect(normalizeArgs(filters(
-                {filters: [{field: 'jgql:lastModified', values: ['last year'], type: 'all'}]},
-                config,
-                {}
-            ))).toMatchInlineSnapshot(`
-              "{
+            )).toMatchInlineSnapshot(`
+              {
+                "query": "query ($jgql_tags_field: String!, $jgql_tags_value: String!) {
                 search(
                   q: ""
                   filters: {
                     custom: {
-                      dateRange: [
+                      term: [
                         {
                           operation: AND
-                          ranges: [{ field: "jgql:lastModified", after: "now-1y", before: "now" }]
+                          terms: [{ field: $jgql_tags_field, value: $jgql_tags_value }]
                         }
                       ]
                     }
@@ -396,33 +531,89 @@ describe('filters', () => {
                 ) {
                   totalHits
                 }
-              }"
+              }",
+                "variables": {
+                  "jgql_tags_field": "jgql:tags",
+                  "jgql_tags_value": "Action",
+                },
+              }
             `);
         });
 
-        it('omits term and dateRange when only a numeric range is selected', () => {
-            expect(normalizeArgs(filters(
-                {filters: [{field: 'popularity', values: ['high'], type: 'all'}]},
+        it('omits term and numberRange when only a date range is selected', () => {
+            expect(argsFor(
+                {filters: [{field: 'jgql:lastModified', values: ['last year'], type: 'all'}]},
                 config,
                 {}
-            ))).toMatchInlineSnapshot(`
-              "{
+            )).toMatchInlineSnapshot(`
+              {
+                "query": "query ($jgql_lastModified_field: String!, $jgql_lastModified_after: String!, $jgql_lastModified_before: String!) {
                 search(
                   q: ""
                   filters: {
                     custom: {
-                      numberRange: [{ operation: AND, ranges: [{ field: "popularity", gte: 500.0, lt: 1000.0 }] }]
+                      dateRange: [
+                        {
+                          operation: AND
+                          ranges: [
+                            {
+                              field: $jgql_lastModified_field
+                              after: $jgql_lastModified_after
+                              before: $jgql_lastModified_before
+                            }
+                          ]
+                        }
+                      ]
                     }
                   }
                 ) {
                   totalHits
                 }
-              }"
+              }",
+                "variables": {
+                  "jgql_lastModified_after": "now-1y",
+                  "jgql_lastModified_before": "now",
+                  "jgql_lastModified_field": "jgql:lastModified",
+                },
+              }
+            `);
+        });
+
+        it('omits term and dateRange when only a numeric range is selected', () => {
+            expect(argsFor(
+                {filters: [{field: 'popularity', values: ['high'], type: 'all'}]},
+                config,
+                {}
+            )).toMatchInlineSnapshot(`
+              {
+                "query": "query ($popularity_field: String!, $popularity_gte: Float!, $popularity_lt: Float!) {
+                search(
+                  q: ""
+                  filters: {
+                    custom: {
+                      numberRange: [
+                        {
+                          operation: AND
+                          ranges: [{ field: $popularity_field, gte: $popularity_gte, lt: $popularity_lt }]
+                        }
+                      ]
+                    }
+                  }
+                ) {
+                  totalHits
+                }
+              }",
+                "variables": {
+                  "popularity_field": "popularity",
+                  "popularity_gte": 500,
+                  "popularity_lt": 1000,
+                },
+              }
             `);
         });
 
         it('emits all three alongside nodeType', () => {
-            expect(normalizeArgs(filters(
+            expect(argsFor(
                 {filters: [
                     {field: 'jgql:tags', values: ['Action'], type: 'all'},
                     {field: 'jgql:lastModified', values: ['last year'], type: 'all'},
@@ -430,27 +621,56 @@ describe('filters', () => {
                 ]},
                 config,
                 {nodeType: 'jnt:page'}
-            ))).toMatchInlineSnapshot(`
-              "{
+            )).toMatchInlineSnapshot(`
+              {
+                "query": "query ($nodeType: String!, $jgql_tags_field: String!, $jgql_tags_value: String!, $jgql_lastModified_field: String!, $jgql_lastModified_after: String!, $jgql_lastModified_before: String!, $popularity_field: String!, $popularity_gte: Float!, $popularity_lt: Float!) {
                 search(
                   q: ""
                   filters: {
-                    nodeType: { type: "jnt:page" }
+                    nodeType: { type: $nodeType }
                     custom: {
-                      term: [{ operation: AND, terms: [{ field: "jgql:tags", value: "Action" }] }]
+                      term: [
+                        {
+                          operation: AND
+                          terms: [{ field: $jgql_tags_field, value: $jgql_tags_value }]
+                        }
+                      ]
                       dateRange: [
                         {
                           operation: AND
-                          ranges: [{ field: "jgql:lastModified", after: "now-1y", before: "now" }]
+                          ranges: [
+                            {
+                              field: $jgql_lastModified_field
+                              after: $jgql_lastModified_after
+                              before: $jgql_lastModified_before
+                            }
+                          ]
                         }
                       ]
-                      numberRange: [{ operation: AND, ranges: [{ field: "popularity", gte: 500.0, lt: 1000.0 }] }]
+                      numberRange: [
+                        {
+                          operation: AND
+                          ranges: [{ field: $popularity_field, gte: $popularity_gte, lt: $popularity_lt }]
+                        }
+                      ]
                     }
                   }
                 ) {
                   totalHits
                 }
-              }"
+              }",
+                "variables": {
+                  "jgql_lastModified_after": "now-1y",
+                  "jgql_lastModified_before": "now",
+                  "jgql_lastModified_field": "jgql:lastModified",
+                  "jgql_tags_field": "jgql:tags",
+                  "jgql_tags_value": "Action",
+                  "nodeType": "jnt:page",
+                  "popularity_field": "popularity",
+                  "popularity_gte": 500,
+                  "popularity_lt": 1000,
+                },
+              }
             `);
         });
     });

--- a/src/__tests__/graphql.test.ts
+++ b/src/__tests__/graphql.test.ts
@@ -1,0 +1,115 @@
+import {enumValue, GraphQLVariables} from '../graphql.js';
+import {assertEveryVariableIsUsed} from './helpers.js';
+
+describe('GraphQLVariables', () => {
+    it('declares nothing when nothing was collected', () => {
+        const variables = new GraphQLVariables();
+        expect(variables.declaration()).toBe('');
+        expect(variables.values()).toEqual({});
+    });
+
+    it('returns the reference to place in the document, and declares it non-null', () => {
+        const variables = new GraphQLVariables();
+        expect(variables.add('q', 'String!', 'hello')).toBe('$q');
+        expect(variables.declaration()).toBe('($q: String!)');
+        expect(variables.values()).toEqual({q: 'hello'});
+    });
+
+    // Two facets can easily want the same hint — `field`, say — and two variables with one name is
+    // not a document the server will accept.
+    it('de-duplicates a repeated hint', () => {
+        const variables = new GraphQLVariables();
+        expect(variables.add('field', 'String!', 'a')).toBe('$field');
+        expect(variables.add('field', 'String!', 'b')).toBe('$field_2');
+        expect(variables.add('field', 'String!', 'c')).toBe('$field_3');
+        expect(variables.values()).toEqual({field: 'a', field_2: 'b', field_3: 'c'});
+    });
+
+    it('does not collide with a hint that already looks like a de-duplicated one', () => {
+        const variables = new GraphQLVariables();
+        variables.add('field_2', 'String!', 'first');
+        variables.add('field', 'String!', 'second');
+        expect(variables.add('field', 'String!', 'third')).toBe('$field_3');
+    });
+
+    // Hints are derived from facet and property names, which carry colons and dots.
+    it('sanitizes a hint into a usable variable name', () => {
+        const variables = new GraphQLVariables();
+        expect(variables.add('jgql:categories.path', 'String!', 'x')).toBe('$jgql_categories_path');
+    });
+
+    it('keeps a hint that starts with a digit from producing an invalid name', () => {
+        const variables = new GraphQLVariables();
+        expect(variables.add('2015', 'String!', 'x')).toBe('$_2015');
+    });
+
+    it('keeps declarations in the order they were added', () => {
+        const variables = new GraphQLVariables();
+        variables.add('q', 'String!', '');
+        variables.add('size', 'Int!', 5);
+        variables.add('disjunctive', 'Boolean!', false);
+        expect(variables.declaration()).toBe('($q: String!, $size: Int!, $disjunctive: Boolean!)');
+    });
+
+    it('hands out a copy, so a caller cannot mutate what will be sent', () => {
+        const variables = new GraphQLVariables();
+        variables.add('q', 'String!', 'hello');
+        variables.values().q = 'tampered';
+        expect(variables.values()).toEqual({q: 'hello'});
+    });
+});
+
+describe('enumValue', () => {
+    it('passes a bare enum name through', () => {
+        expect(enumValue('workspace', 'LIVE')).toBe('LIVE');
+        expect(enumValue('sortDirection', 'ASC')).toBe('ASC');
+        expect(enumValue('workspace', '_private2')).toBe('_private2');
+    });
+
+    it.each([
+        ['a quoted string', '"LIVE"'],
+        ['something that closes the argument list', 'LIVE) {id} evil('],
+        ['a value with a space', 'not an enum'],
+        ['a value starting with a digit', '2workspaces'],
+        ['an empty value', '']
+    ])('rejects %s', (_name, value) => {
+        expect(() => enumValue('workspace', value)).toThrow('workspace must be a GraphQL enum value');
+    });
+
+    it('names the offending value in the error', () => {
+        expect(() => enumValue('workspace', 'not an enum')).toThrow('"not an enum"');
+    });
+});
+
+// The guard the fragment helpers rely on. A variable declared but never referenced makes a query
+// invalid, and nothing else in the suite would notice — so the guard itself needs pinning.
+describe('assertEveryVariableIsUsed', () => {
+    it('accepts a document that references every variable it declares', () => {
+        expect(() => assertEveryVariableIsUsed({
+            query: 'query ($q: String!) {\n  search(q: $q) {\n    totalHits\n  }\n}',
+            variables: {q: 'hello'}
+        })).not.toThrow();
+    });
+
+    it('rejects a document that declares a variable it never references', () => {
+        expect(() => assertEveryVariableIsUsed({
+            query: 'query ($q: String!, $unused: Int!) {\n  search(q: $q) {\n    totalHits\n  }\n}',
+            variables: {q: 'hello', unused: 1}
+        })).toThrow('Declared but never referenced in the document: unused');
+    });
+
+    it('rejects a value with no matching variable in the document at all', () => {
+        expect(() => assertEveryVariableIsUsed({
+            query: 'query ($q: String!) {\n  search(q: $q) {\n    totalHits\n  }\n}',
+            variables: {q: 'hello', orphan: 'sent but never declared'}
+        })).toThrow('Declared but never referenced in the document: orphan');
+    });
+
+    // `$q` must not be counted as a reference to `$q_2`, or a genuinely unused variable slips past.
+    it('does not treat a prefix of a longer name as a reference', () => {
+        expect(() => assertEveryVariableIsUsed({
+            query: 'query ($q: String!, $q_2: String!) {\n  search(q: $q) {\n    totalHits\n  }\n}',
+            variables: {q: 'hello', q_2: 'unused'}
+        })).toThrow('Declared but never referenced in the document: q_2');
+    });
+});

--- a/src/__tests__/helpers.ts
+++ b/src/__tests__/helpers.ts
@@ -1,4 +1,6 @@
-import {parse, print} from 'graphql';
+import {parse, parseValue, print, visit} from 'graphql';
+import {GraphQLVariables} from '../graphql.js';
+import type {GraphQLRequest} from '../types.js';
 
 /**
  * `filters()` and `facets()` return GraphQL *fragments* that `adaptRequest` interpolates into a
@@ -6,13 +8,68 @@ import {parse, print} from 'graphql';
  * raw spacing of a fragment is not observable from outside the package — only the GraphQL it parses
  * to is. These helpers apply the same round-trip, which is the granularity a rewrite has to match:
  * strict about structure and argument values, indifferent to layout.
+ *
+ * A fragment now also registers the values it needs on a shared {@link GraphQLVariables}, so the
+ * helpers take a builder rather than a finished string: they own the bag, hand it to the fragment,
+ * and report the document and the values together.
  */
 
+/** A normalized fragment: the document it parses to, and the values it asks to be sent. */
+export interface NormalizedFragment {
+    query: string;
+    variables: Record<string, unknown>;
+}
+
+/**
+ * A variable that is declared but never referenced makes the whole query invalid, and neither
+ * `parse` nor a snapshot notices. Every helper checks it, so no spec can pin a query the server
+ * would reject.
+ */
+export const assertEveryVariableIsUsed = ({query, variables}: GraphQLRequest): void => {
+    const unused = Object.keys(variables).filter(name => {
+        const references = query.match(new RegExp(`\\$${name}\\b`, 'g')) ?? [];
+        // One reference is the declaration itself; a used variable appears at least twice.
+        return references.length < 2;
+    });
+    if (unused.length > 0) {
+        throw new Error(`Declared but never referenced in the document: ${unused.join(', ')}`);
+    }
+};
+
+const normalize = (document: string, variables: GraphQLVariables): NormalizedFragment => {
+    const normalized = {query: print(parse(document)), variables: variables.values()};
+    assertEveryVariableIsUsed(normalized);
+    return normalized;
+};
+
 /** Normalize an argument-list fragment, as returned by `filters()`. */
-export const normalizeArgs = (fragment: string): string => print(parse(`query { search(q: "" ${fragment}) { totalHits } }`));
+export const normalizeArgs = (build: (variables: GraphQLVariables) => string): NormalizedFragment => {
+    const variables = new GraphQLVariables();
+    const fragment = build(variables);
+    return normalize(`query ${variables.declaration()} { search(q: "" ${fragment}) { totalHits } }`, variables);
+};
 
 /** Normalize a selection-set fragment, as returned by `facets()`. */
-export const normalizeSelections = (fragment: string): string => print(parse(`query { search { totalHits ${fragment} } }`));
+export const normalizeSelections = (build: (variables: GraphQLVariables) => string): NormalizedFragment => {
+    const variables = new GraphQLVariables();
+    const fragment = build(variables);
+    return normalize(`query ${variables.declaration()} { search { totalHits ${fragment} } }`, variables);
+};
 
-/** Pull the `q:` argument out of a printed query, to assert on search-term escaping. */
-export const searchTermArgOf = (query: string): string => query.match(/q: "[^\n]*/)![0];
+/**
+ * Substitute a request's variables back into its document.
+ *
+ * The whole point of parameterizing is that no value appears in the query text, which makes the
+ * document on its own a poor thing to state an expectation against — it says nothing about what is
+ * actually being searched for. Putting the values back yields the query the request *means*, so a
+ * spec can write that out in full, independently of how it happens to be parameterized. The
+ * expectations that predate variables are still readable, and still assert the same thing.
+ */
+export const inlineVariables = ({query, variables}: GraphQLRequest): string => {
+    const withoutDefinitions = visit(parse(query), {
+        OperationDefinition: node => ({...node, variableDefinitions: []})
+    });
+    return print(visit(withoutDefinitions, {
+        Variable: node => parseValue(JSON.stringify(variables[node.name.value]))
+    }));
+};

--- a/src/__tests__/request.test.ts
+++ b/src/__tests__/request.test.ts
@@ -30,9 +30,17 @@ function respondWithError(json?: unknown) {
     global.fetch = vi.fn().mockReturnValue(fetchResponse(json, 401));
 }
 
+const graphQLRequest = {query: 'query ($q: String!) { search(q: $q) { totalHits } }', variables: {q: 'test'}};
+
 function subject() {
-    return request('engine', 'http://localhost:8080', 'GET', 'test');
+    return request('engine', 'http://localhost:8080', 'GET', graphQLRequest);
 }
+
+it('posts the document and its variables together', async () => {
+    respondWithSuccess(responseJson);
+    await subject();
+    expect(JSON.parse(vi.mocked(global.fetch).mock.calls[0][1]!.body as string)).toEqual(graphQLRequest);
+});
 
 it('will return json on successful request with json', async () => {
     respondWithSuccess(responseJson);

--- a/src/__tests__/sort.test.ts
+++ b/src/__tests__/sort.test.ts
@@ -58,4 +58,20 @@ describe('Sort parameters tests', function () {
         const query = adaptRequest(requestOptions, state, queryConfig);
         expect(query).toMatchSnapshot();
     });
+
+    // `dir` is a GraphQL enum, so it is the one part of the sort that still goes into the document
+    // rather than into a variable. It is checked instead: a direction that is not a bare enum name
+    // is rejected here rather than concatenated into the query.
+    it('rejects a sort direction that is not a GraphQL enum value', function () {
+        state.sortDirection = 'asc} evil {';
+        state.sortField = 'jcr:title';
+        expect(() => adaptRequest(requestOptions, state, queryConfig))
+            .toThrow('sortDirection must be a GraphQL enum value');
+    });
+
+    it('accepts a direction the backend may still reject, without guessing the schema', function () {
+        state.sortDirection = 'sideways';
+        state.sortField = 'jcr:title';
+        expect(adaptRequest(requestOptions, state, queryConfig).query).toContain('dir: SIDEWAYS');
+    });
 });

--- a/src/adaptRequest.ts
+++ b/src/adaptRequest.ts
@@ -3,54 +3,47 @@ import {parse, print} from 'graphql';
 import sort from './sort.js';
 import facets from './facets.js';
 import filters from './filters.js';
-import type {QueryConfig, RequestOptions, RequestState} from './types.js';
+import {enumValue, GraphQLVariables} from './graphql.js';
+import type {GraphQLRequest, QueryConfig, RequestOptions, RequestState} from './types.js';
 
 interface ConcatenatedFields {
     hitFields: string;
     nodeFields: string;
 }
 
-const buildFields = (fields: Field[]): ConcatenatedFields => {
+const buildFields = (fields: Field[], variables: GraphQLVariables): ConcatenatedFields => {
     const fieldsConcatenated: ConcatenatedFields = {
         hitFields: '',
         nodeFields: ''
     };
     fields.forEach(field => {
         if (field.type === FieldType.HIT) {
-            fieldsConcatenated.hitFields = `${fieldsConcatenated.hitFields},${field.resolveRequestField()}`;
+            fieldsConcatenated.hitFields = `${fieldsConcatenated.hitFields},${field.resolveRequestField(variables)}`;
         } else {
-            fieldsConcatenated.nodeFields = `${fieldsConcatenated.nodeFields},${field.resolveRequestField()}`;
+            fieldsConcatenated.nodeFields = `${fieldsConcatenated.nodeFields},${field.resolveRequestField(variables)}`;
         }
     });
     return fieldsConcatenated;
 };
 
-function htmlEscape(str: string | undefined): string {
-    if (str) {
-        return String(str)
-            .replace(/&/g, '&amp;')
-            .replace(/"/g, '&quot;')
-            .replace(/'/g, '&#39;')
-            .replace(/</g, '&lt;')
-            .replace(/>/g, '&gt;')
-            .replace(/\\/g, '\\\\');
-    }
-
-    return '';
-}
-
 /**
  * Adapt the request from Search UI to Jahia Augmented Search
+ *
+ * Every value is sent as a GraphQL variable rather than written into the query text. The two
+ * exceptions are enums (`workspace` and the sort direction), which cannot be variables without
+ * knowing the schema's type names, and response keys — a GraphQL alias is part of the document's
+ * structure. Both are validated or derived from the application's own configuration.
+ *
  * @param requestOptions the options for this request
  * @param request the state of the current request
  * @param queryConfig the query configuration as defined when initializing the App
- * @returns the graphql query to be executed on a Jahia backend
+ * @returns the graphql query to be executed on a Jahia backend, and the values it needs
  */
 export default function adaptRequest(
     requestOptions: RequestOptions,
     request: RequestState,
     queryConfig: QueryConfig
-): string {
+): GraphQLRequest {
     const graphQLOptions = {
         resultsPerPage: 5,
         current: 1,
@@ -63,21 +56,27 @@ export default function adaptRequest(
     // both shapes the config may take — the array used in practice, and a plain record — in the same
     // order the original's Object.keys walk did.
     const declaredFields: unknown[] = Object.values(resultFields!);
-    const resolvedRequestFields = buildFields(declaredFields.filter((field): field is Field => field instanceof Field));
 
-    return print(parse(`query {
+    const variables = new GraphQLVariables();
+    const resolvedRequestFields = buildFields(declaredFields.filter((field): field is Field => field instanceof Field), variables);
+    // An absent search term still searches for the empty string. A term that is not a string is
+    // coerced rather than dropped, so a numeric 0 searches for "0".
+    const searchTerm = graphQLOptions.searchTerm === undefined ? '' : String(graphQLOptions.searchTerm);
+
+    // Built before the declaration list is read: every add() has to have happened by then.
+    const operation = `{
         search(
-            q: "${graphQLOptions.searchTerm === undefined ? '' : htmlEscape(graphQLOptions.searchTerm)}",
-            siteKeys: ["${graphQLOptions.siteKey}"],
-            language: "${graphQLOptions.language}",
-            workspace: ${graphQLOptions.workspace},
-            functionScoreId: "${graphQLOptions.functionScore}",
-            ${filters(request, queryConfig, graphQLOptions)}
+            q: ${variables.add('q', 'String!', searchTerm)},
+            siteKeys: [${variables.add('siteKey', 'String!', graphQLOptions.siteKey)}],
+            language: ${variables.add('language', 'String!', graphQLOptions.language)},
+            workspace: ${enumValue('workspace', graphQLOptions.workspace)},
+            functionScoreId: ${variables.add('functionScoreId', 'String!', graphQLOptions.functionScore)},
+            ${filters(request, queryConfig, graphQLOptions, variables)}
             ) {
 
-            results(size: ${graphQLOptions.resultsPerPage},
-                    page: ${graphQLOptions.current - 1}
-                    ${sort(request)}
+            results(size: ${variables.add('size', 'Int!', graphQLOptions.resultsPerPage)},
+                    page: ${variables.add('page', 'Int!', graphQLOptions.current - 1)}
+                    ${sort(request, variables)}
                     ) {
                 totalHits
                 took
@@ -88,7 +87,12 @@ export default function adaptRequest(
                 }
             }
 
-            ${facets(request, queryConfig)}
+            ${facets(request, queryConfig, variables)}
         }
-    }`));
+    }`;
+
+    return {
+        query: print(parse(`query ${variables.declaration()} ${operation}`)),
+        variables: variables.values()
+    };
 }

--- a/src/facets.ts
+++ b/src/facets.ts
@@ -1,84 +1,80 @@
-import type {FacetConfig, FacetRange, QueryConfig, RequestFilter, RequestState} from './types.js';
+import type {GraphQLVariables} from './graphql.js';
+import type {FacetConfig, FacetRange, QueryConfig, RequestState} from './types.js';
 
-interface ProcessedFacet {
-    facet: FacetConfig;
-    selections?: string[];
-}
-
-function buildRangeValue(range: FacetRange): string {
-    const args = [`name: "${range.name}"`];
-    if (range.from) {
-        args.push(`from: "${range.from}"`);
+/**
+ * `{name: $n, from: $f, to: $t}` — a bound that is not configured is left out of the object rather
+ * than sent as null, since the variables are declared non-null.
+ */
+function buildRangeValue(range: FacetRange, hint: string, variables: GraphQLVariables): string {
+    const args = [`name: ${variables.add(`${hint}_name`, 'String!', range.name)}`];
+    if (range.from !== undefined) {
+        args.push(`from: ${variables.add(`${hint}_from`, 'String!', String(range.from))}`);
     }
 
-    if (range.to) {
-        args.push(`to: "${range.to}"`);
+    if (range.to !== undefined) {
+        args.push(`to: ${variables.add(`${hint}_to`, 'String!', String(range.to))}`);
     }
 
     return `{${args.join(',')}}`;
 }
 
-export default function facets(request: RequestState, queryConfig: QueryConfig): string {
+/**
+ * `_request` is deliberately unused. The previous implementation walked `request.filters` into a
+ * `selections` array that nothing ever read; registering variables for it now would declare
+ * variables the document never references, which makes the query invalid. The parameter stays so
+ * the "ignores request filters entirely" characterization test can keep asserting that a request's
+ * filters make no difference to the facet query.
+ */
+export default function facets(_request: RequestState, queryConfig: QueryConfig, variables: GraphQLVariables): string {
     if (!queryConfig.facets || Object.entries(queryConfig.facets).length === 0) {
         return '';
     }
 
-    const processedFacets: Record<string, Record<string, ProcessedFacet>> = {};
-
-    function extractSelections(filters: RequestFilter[], facetName: string, facet: FacetConfig): void {
-        const selections: string[] = [];
-        filters.filter(filter => facetName === filter.field).forEach(filter => {
-            switch (facet.type) {
-                case 'range':
-                case 'date_range':
-                    // The cast records the assumption this branch makes: a range selection is a
-                    // FacetRange, not the plain string a value facet reports. Nothing reads
-                    // `selections`, so it is never exercised — see the note in facets.test.ts.
-                    filter.values.forEach(value => selections.push(buildRangeValue(value as FacetRange)));
-                    break;
-                case 'value':
-                default:
-                    filter.values.forEach(value => selections.push(`"${value}"`));
-                    break;
-            }
-        });
-        processedFacets[facet.type][facetName].selections = selections;
-    }
-
+    // Grouped by type, so value facets are emitted before range facets, as before.
+    const byType: Record<string, Record<string, FacetConfig>> = {};
     Object.entries(queryConfig.facets).forEach(([facetName, facet]) => {
-        // Handle filter values
-        const filters = request.filters;
-        if (processedFacets[facet.type] === undefined) {
-            processedFacets[facet.type] = {};
+        if (byType[facet.type] === undefined) {
+            byType[facet.type] = {};
         }
 
-        processedFacets[facet.type][facetName] = {facet: facet};
-        if (filters) {
-            extractSelections(filters, facetName, facet);
-        }
+        byType[facet.type][facetName] = facet;
     });
+
     const facetInputs: string[] = [];
-    Object.values(processedFacets).forEach(facetGroup => {
-        Object.entries(facetGroup).forEach(([facetName, processed]) => {
-            // The group key is the facet's own `type`, so switching on the config discriminates on
-            // exactly the same value as the original did on the key — and narrows the union.
-            const facet = processed.facet;
+    Object.values(byType).forEach(group => {
+        Object.entries(group).forEach(([facetName, facet]) => {
+            // The response key is written into the document: a GraphQL alias cannot be a variable.
+            // It comes from the application's facet configuration, not from visitor input.
+            const responseKey = facetName.replace(/[:.]/g, '_');
+            // Every one of these is registered lazily, inside the branch that writes it into the
+            // document: a declared variable the document never references makes the query invalid,
+            // and a facet with an unrecognised type is dropped without emitting anything at all.
+            const field = () => variables.add(`${responseKey}_field`, 'String!', facetName);
+            // Left out when not configured, rather than sent as null.
+            const max = () => facet.max === undefined ? '' : `, max: ${variables.add(`${responseKey}_max`, 'Int!', facet.max)}`;
+            const minDocCount = () => facet.minDoc === undefined ? '' : `, minDocCount: ${variables.add(`${responseKey}_minDocCount`, 'Int!', facet.minDoc)}`;
+
             if (facet.type === 'value') {
-                if (facet.hierarchical === true) {
-                    facetInputs.push(`${facetName.replace(/[:.]/g, '_')}: treeFacet(field:"${facetName}", rootPath: "${facet.rootPath}", disjunctive: ${Boolean(facet.disjunctive)} 
-                ${facet.max ? `, max: ${facet.max},` : ''} ${facet.minDoc ? `, minDocCount: ${facet.minDoc},` : ''}) {
+                const hierarchical = facet.hierarchical === true;
+                const rootPath = hierarchical && facet.rootPath !== undefined ?
+                    `rootPath: ${variables.add(`${responseKey}_rootPath`, 'String!', facet.rootPath)}, ` :
+                    '';
+                const disjunctive = variables.add(`${responseKey}_disjunctive`, 'Boolean!', Boolean(facet.disjunctive));
+                if (hierarchical) {
+                    facetInputs.push(`${responseKey}: treeFacet(field:${field()}, ${rootPath}disjunctive: ${disjunctive}${max()}${minDocCount()}) {
                 data{value,count,key,hasChildren,rootPath,filter}}`);
                 } else {
-                    facetInputs.push(`${facetName.replace(/[:.]/g, '_')}: termFacet(field:"${facetName}", disjunctive: ${Boolean(facet.disjunctive)} 
-                ${facet.max ? `, max: ${facet.max},` : ''} ${facet.minDoc ? `, minDocCount: ${facet.minDoc},` : ''}) {
+                    facetInputs.push(`${responseKey}: termFacet(field:${field()}, disjunctive: ${disjunctive}${max()}${minDocCount()}) {
                 data{value,count}}`);
                 }
             } else if (facet.type === 'date_range' || facet.type === 'range') {
                 // Deliberately not a bare `else`: a facet whose type is neither value nor range is
-                // dropped rather than emitted, which is what the current implementation does.
-                facetInputs.push(`${facetName.replace(/[:.]/g, '_')}:rangeFacet(field: "${facetName}", 
-               ranges:[${facet.ranges.map(range => `${buildRangeValue(range)}`).join(',')}] 
-                ${facet.max ? `, max: ${facet.max},` : ''}) {
+                // dropped rather than emitted, which is what the previous implementation did.
+                // Note there is no minDocCount here either — range facets never sent one.
+                const ranges = facet.ranges
+                    .map((range, index) => buildRangeValue(range, `${responseKey}_${index}`, variables))
+                    .join(',');
+                facetInputs.push(`${responseKey}:rangeFacet(field: ${field()}, ranges:[${ranges}]${max()}) {
                 data{name,count}}`);
             }
         });

--- a/src/field.ts
+++ b/src/field.ts
@@ -1,3 +1,4 @@
+import type {GraphQLVariables} from './graphql.js';
 import type {ResultField, SearchHit, SearchResult} from './types.js';
 
 const FieldType = {
@@ -32,13 +33,21 @@ class Field {
         this.useSnippet = useSnippet;
     }
 
-    resolveRequestField(): string {
+    /**
+     * The selection for this field.
+     *
+     * The response key is written into the document — a GraphQL alias cannot be a variable — so it
+     * has to be a bare name. Both it and the selected `name` come from the application's own field
+     * configuration rather than from anything a visitor types.
+     */
+    resolveRequestField(variables: GraphQLVariables): string {
+        const responseKey = this.alias ? this.alias : this.name.replace(':', '_');
         let fieldTemplate: string;
         switch (this.type) {
             case FieldType.REFERENCE_AS_VALUE:
             case FieldType.REFERENCE_AS_PATH:
             case FieldType.NODE:
-                fieldTemplate = `${this.alias ? this.alias : this.name.replace(':', '_')} : property(name: "${this.name}")`;
+                fieldTemplate = `${responseKey} : property(name: ${variables.add(`${responseKey}_name`, 'String!', this.name)})`;
                 break;
             case FieldType.HIT:
             default:

--- a/src/filters.ts
+++ b/src/filters.ts
@@ -1,3 +1,4 @@
+import type {GraphQLVariables} from './graphql.js';
 import type {FacetConfig, FacetRange, QueryConfig, RequestState} from './types.js';
 
 interface TermGroup {
@@ -9,11 +10,12 @@ interface TermGroup {
 export default function filters(
     request: RequestState,
     queryConfig: QueryConfig,
-    graphQLOptions: {nodeType?: string}
+    graphQLOptions: {nodeType?: string},
+    variables: GraphQLVariables
 ): string {
     const filters: string[] = [];
     if (graphQLOptions.nodeType) {
-        filters.push(`nodeType:{type: "${graphQLOptions.nodeType}"}`);
+        filters.push(`nodeType:{type: ${variables.add('nodeType', 'String!', graphQLOptions.nodeType)}}`);
     }
 
     function getTerms(terms: Record<string, TermGroup>): string {
@@ -31,6 +33,11 @@ export default function filters(
         return `numberRange: [${numberRangesArray}]`;
     }
 
+    /** `{field: $x, value: $y}` — both sides parameterized, so neither reaches the document. */
+    function term(field: string, value: unknown): string {
+        return `{field:${variables.add(`${field}_field`, 'String!', field)}, value:${variables.add(`${field}_value`, 'String!', value)}}`;
+    }
+
     if (request.filters !== undefined && request.filters.length > 0) {
         const terms: Record<string, TermGroup> = {};
         const dateRanges: Record<string, string[]> = {};
@@ -41,7 +48,7 @@ export default function filters(
             const facet: FacetConfig | undefined = queryConfig.facets![filter.field];
             if (facet === undefined) {
                 terms[filter.field] = {type: filter.type, terms: []};
-                terms[filter.field].terms.push(`{field:"${filter.field}", value:"${filter.values[0]}"}`);
+                terms[filter.field].terms.push(term(filter.field, filter.values[0]));
             } else {
                 switch (facet.type) {
                     case 'range':
@@ -55,7 +62,12 @@ export default function filters(
                                 numberRange = [];
                             }
 
-                            numberRange.push(`{field:"${filter.field}",gte:${range.from}, lt:${range.to}}`);
+                            // gte/lt are numeric: the previous implementation interpolated the
+                            // configured bound unquoted, producing a Float literal, so the bound is
+                            // converted rather than sent as the string the config declares it as.
+                            numberRange.push(`{field:${variables.add(`${filter.field}_field`, 'String!', filter.field)}, ` +
+                                `gte:${variables.add(`${filter.field}_gte`, 'Float!', Number(range.from))}, ` +
+                                `lt:${variables.add(`${filter.field}_lt`, 'Float!', Number(range.to))}}`);
                             numberRanges[filter.field] = numberRange;
                         });
                         break;
@@ -68,20 +80,22 @@ export default function filters(
                                 dateRange = [];
                             }
 
-                            dateRange.push(`{field:"${filter.field}",after:"${range.from}", before:"${range.to}"}`);
+                            dateRange.push(`{field:${variables.add(`${filter.field}_field`, 'String!', filter.field)}, ` +
+                                `after:${variables.add(`${filter.field}_after`, 'String!', range.from)}, ` +
+                                `before:${variables.add(`${filter.field}_before`, 'String!', range.to)}}`);
                             dateRanges[filter.field] = dateRange;
                         });
                         break;
                     case 'value':
                     default:
                         filter.values.forEach(value => {
-                            let term: TermGroup | undefined = terms[filter.field];
-                            if (term === undefined) {
-                                term = {type: filter.type, terms: []};
+                            let group: TermGroup | undefined = terms[filter.field];
+                            if (group === undefined) {
+                                group = {type: filter.type, terms: []};
                             }
 
-                            term.terms.push(`{field:"${filter.field}", value:"${value}"}`);
-                            terms[filter.field] = term;
+                            group.terms.push(term(filter.field, value));
+                            terms[filter.field] = group;
                         });
                         break;
                 }

--- a/src/graphql.ts
+++ b/src/graphql.ts
@@ -1,0 +1,71 @@
+/** The built-in scalars this package sends values as. Always non-null — see {@link GraphQLVariables}. */
+export type GraphQLScalar = 'String!' | 'Int!' | 'Float!' | 'Boolean!';
+
+const ENUM_VALUE = /^[_A-Za-z][_0-9A-Za-z]*$/;
+
+/**
+ * Check that a value can be written into the document as a GraphQL enum.
+ *
+ * Enums are the one thing a variable cannot replace without knowing the schema's type names, so
+ * `workspace` and the sort direction are still written into the document itself. Validating the
+ * shape is what keeps that from being an injection point: anything that is not a bare enum name is
+ * rejected here rather than concatenated in.
+ */
+export function enumValue(argument: string, value: string): string {
+    if (!ENUM_VALUE.test(value)) {
+        throw new Error(`search-ui-jahia-connector: ${argument} must be a GraphQL enum value, got ${JSON.stringify(value)}`);
+    }
+
+    return value;
+}
+
+/**
+ * Collects the values a query needs, hands back the `$name` to write into the document, and builds
+ * the matching variable declarations.
+ *
+ * Every variable is declared non-null. A nullable variable cannot be used where the schema declares
+ * a non-null argument, and this package does not know the schema — `T!` is accepted in both
+ * positions. The consequence is that there is no way to send an explicit null, so an argument whose
+ * value is absent is left out of the document rather than passed as null.
+ */
+export class GraphQLVariables {
+    private readonly declarations: string[] = [];
+    private readonly collected: Record<string, unknown> = {};
+
+    /**
+     * Register a value and return the `$name` to place in the document.
+     *
+     * `hint` only shapes the variable name, to keep a printed query readable; it is sanitized and
+     * de-duplicated, so any string is safe to pass.
+     */
+    add(hint: string, type: GraphQLScalar, value: unknown): string {
+        const name = this.uniqueName(hint);
+        this.declarations.push(`$${name}: ${type}`);
+        this.collected[name] = value;
+        return `$${name}`;
+    }
+
+    /** The `($a: String!, $b: Int!)` clause for the operation, or `''` when nothing was collected. */
+    declaration(): string {
+        return this.declarations.length === 0 ? '' : `(${this.declarations.join(', ')})`;
+    }
+
+    /** The values to send alongside the document. */
+    values(): Record<string, unknown> {
+        return {...this.collected};
+    }
+
+    private uniqueName(hint: string): string {
+        const base = hint.replace(/[^_0-9A-Za-z]/g, '_').replace(/^[0-9]/, '_$&');
+        if (!(base in this.collected)) {
+            return base;
+        }
+
+        let suffix = 2;
+        while (`${base}_${suffix}` in this.collected) {
+            suffix++;
+        }
+
+        return `${base}_${suffix}`;
+    }
+}

--- a/src/request.ts
+++ b/src/request.ts
@@ -1,8 +1,10 @@
+import type {GraphQLRequest} from './types.js';
+
 export default async function request<T = unknown>(
     apiToken: string,
     baseURL: string,
     method: string,
-    query: string
+    graphQLRequest: GraphQLRequest
 ): Promise<T> {
     const headers = new Headers({
         'Content-Type': 'application/json',
@@ -14,9 +16,7 @@ export default async function request<T = unknown>(
         {
             method,
             headers,
-            body: JSON.stringify({
-                query
-            }),
+            body: JSON.stringify(graphQLRequest),
             credentials: 'include'
         }
     );

--- a/src/sort.ts
+++ b/src/sort.ts
@@ -1,3 +1,4 @@
+import {enumValue, type GraphQLVariables} from './graphql.js';
 import type {RequestState} from './types.js';
 
 type SortedState = RequestState & {sortDirection: string; sortField: string};
@@ -14,10 +15,12 @@ function hasSortFields(state: RequestState | null): state is SortedState {
 }
 
 // Generate sort field
-export default function sort(state: RequestState | null): string {
+export default function sort(state: RequestState | null, variables: GraphQLVariables): string {
     if (!hasSortFields(state)) {
         return '';
     }
 
-    return `, sortBy: { dir: ${state.sortDirection.toUpperCase()}, field: "${state.sortField}"}`;
+    // `dir` is an enum, so it stays in the document and is validated instead of parameterized.
+    const dir = enumValue('sortDirection', state.sortDirection.toUpperCase());
+    return `, sortBy: { dir: ${dir}, field: ${variables.add('sortField', 'String!', state.sortField)}}`;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -7,6 +7,12 @@ import type {Field} from './field.js';
  * its whole request state and query config to the connector, and only a subset of each is used.
  */
 
+/** A GraphQL document and the values it needs, as posted to the API. */
+export interface GraphQLRequest {
+    query: string;
+    variables: Record<string, unknown>;
+}
+
 /** A single value on an adapted result, as consumed by Search UI's View components. */
 export interface ResultField {
     raw?: unknown;


### PR DESCRIPTION
Stacked on #103, which is stacked on #102 — review those first; this diff is against #103's branch.

Third and final step of the refactor.

## Why

Every value was written into the query text. The search term went through an `htmlEscape()` that was the only barrier against a visitor's input reaching the document, and it failed in both directions:

- it mangled ordinary searches — `Ben & Jerry's` searched for `Ben &amp; Jerry&#39;s`
- it still did not stop a newline from breaking the query

Filter values had no barrier at all: a single quote produced a document that could not be parsed.

Values are now GraphQL variables. Proof, running the built `dist` against a stubbed `fetch` with `") { id } evilField # ` as both the search term and a facet value:

```
body keys: query, variables
document parses: yes
document contains the hostile input: false
variables carry it verbatim: 2 time(s)
declared but not supplied: 0 | declared but unreferenced: 0
```

## What still isn't a variable, and why

**There is no GraphQL schema in this repo.** That constrained the design, and it's the main thing to push back on if you disagree.

Without the schema I don't know the type names for `filters`, `sortBy`, the workspace enum, or the range inputs — and a wrong type name produces a document that compiles, passes every test here (nothing validates against a schema), and is rejected by every real server. So only **leaf scalars** are parameterized; the input-object literals stay inline with `$var` leaves, which needs nothing but the built-in scalars.

Two things remain in the document:

| | Why | Mitigation |
| --- | --- | --- |
| enums (`workspace`, sort direction) | can't be a variable without the schema's enum type name | validated against the GraphQL enum-name *grammar* — a value that isn't a bare name throws. The grammar rather than a fixed set (`LIVE`/`DEFAULT`/…) because guessing the schema's values would reject configs that work today |
| response keys (`jgql_tags:`, `created:`) | a GraphQL alias is structural | derived from the application's own field and facet configuration, never from visitor input |

Every variable is declared **non-null**: a nullable variable may not be used where the schema declares a non-null argument, and `T!` is valid in both positions. The consequence is that there's no way to send an explicit null, so an absent value means the argument is omitted entirely.

**Known limitation:** the document still varies with the *number* of selected filter values, so it isn't a stable cache key across arbitrary requests (it is stable across changing search term and page). Collapsing `filters` into one input-object variable would fix that and needs the schema type name — natural follow-up if you can point me at it.

## Behaviour changes

Each characterization test was rewritten from pinning the bug to pinning the fix, and says so.

| Fixed | Was |
| --- | --- |
| search terms sent verbatim | HTML-escaped, backslashes doubled, entities double-escaped |
| a newline searches | threw `Syntax Error: Unterminated string` |
| numeric `0` searches for `"0"` | discarded, searched for everything |
| filter values with quotes work | produced an unparseable query |
| facet range bound of `0` kept | dropped, range became open-ended |
| tree facet omits an unset `rootPath` | sent the literal string `"undefined"` |
| bad `workspace` / sort direction throw | silently produced a query the server rejects |

**Deliberately not fixed**, still pinned as known bugs — unrelated to parameterizing, and worth their own change: only `values[0]` reaching the query for an undeclared field, the unhandled range-name miss, and the response-side facet lookup.

`gte`/`lt` now print as `500` rather than `500.0`. The bounds are configured as the strings `"500.0"`/`"1000.0"` and used to be interpolated raw, which happened to look like a Float literal; they're now converted and sent as numbers. Same value for a `Float` argument. It's the only diff in the `adapts filtered request` expectation.

## A failure mode worth knowing about

A variable that is **declared but never referenced** makes the whole query invalid — and neither `parse()` nor a snapshot notices. I hit this twice while writing it (a facet with an unrecognised type, and `minDoc` on a range facet, which never sends a `minDocCount`). It's now guarded rather than just fixed:

- `assertEveryVariableIsUsed` runs inside every fragment helper, so no spec can pin a query the server would reject
- `adaptRequest` is checked against the six configurations most likely to regress it
- the guard itself has tests, including that `$q` isn't counted as a reference to `$q_2`

`extractSelections` in `facets()` is **removed**. It was dead code — nothing read the `selections` it built, as the previous test comment noted — and keeping it would have registered exactly those phantom variables. The `_request` parameter stays so `ignores request filters entirely` can keep asserting what it was invisible to.

## On the test expectations

The three structural tests are 160 lines of hand-written GraphQL, and they're the most valuable thing in the suite because they're an *independent statement of intent* rather than a recording. Rather than replace them with snapshots, they now go through `inlineVariables()`, which substitutes the values back — so they still read as the query the request *means*.

Two of the three passed **completely unchanged**, which is the best evidence available that parameterizing didn't alter what's being asked for.

The parameterized documents themselves are pinned by the `sort.test.ts` external snapshots and by the `filters`/`facets` specs, which now assert on `{query, variables}` together.

125 tests, coverage back at 100% across the board. README examples still compile against the built `dist`.
